### PR TITLE
feat: order-service 도메인 설계 및 구현

### DIFF
--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -9,7 +9,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+//    implementation 'org.springframework.boot:spring-boot-starter-kafka'
+//    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
     runtimeOnly 'org.postgresql:postgresql'
+    runtimeOnly 'com.h2database:h2' // 초기 빌드용
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
@@ -71,7 +71,7 @@ public class Order {
 
     private void calculateTotalAmount() {
         this.totalAmount = Money.of(orderItems.stream()
-                .mapToLong(x -> x.getSubTotal().getAmount())
+                .mapToLong(x -> x.getSubTotal().amount())
                 .sum());
     }
 

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
@@ -24,10 +24,11 @@ public class Order {
     private Supplier supplier;
     private Receiver receiver;
     private UUID deliveryId;
-    private OrderStatus status;
     private Money totalAmount;
     private LocalDateTime dueDate;
     private String requestMemo;
+    private OrderStatus status;
+    private OrderStatus previousStatus;
     private List<OrderItem> orderItems;
 
     public static Order create(
@@ -44,10 +45,11 @@ public class Order {
                 Supplier.of(supplierCompanyId, supplierManagerId),
                 Receiver.of(receiverCompanyId, receiverManagerId),
                 null,
-                OrderStatus.PENDING,
                 Money.of(0L),
                 dueDate,
                 requestMemo,
+                OrderStatus.PENDING,
+                null,
                 new ArrayList<>()
         );
 
@@ -86,6 +88,20 @@ public class Order {
                 .sum());
     }
 
+    public void reserve(boolean isSuccess) {
+        OrderStatus resultStatus = isSuccess ? OrderStatus.RESERVED : OrderStatus.CANCELLED;
+
+        // 취소 요청 상태에서는 이전 상태 업데이트
+        if (this.status == OrderStatus.CANCEL_REQUESTED) {
+            this.previousStatus.validateNext(resultStatus);
+            this.previousStatus = resultStatus;
+            return;
+        }
+
+        this.status.validateNext(resultStatus);
+        this.status = resultStatus;
+    }
+
     public void accept() {
         this.status.validateNext(OrderStatus.ACCEPTED);
         this.status = OrderStatus.ACCEPTED;
@@ -115,8 +131,23 @@ public class Order {
         this.status = OrderStatus.COMPLETED;
     }
 
+    // 주문 취소 / 거절 / 취소 요청 승인 (나중에 필요하면 분리)
     public void cancel() {
         this.status.validateNext(OrderStatus.CANCELLED);
         this.status = OrderStatus.CANCELLED;
+        this.previousStatus = null; // 취소 요청이었다면 이전 상태 초기화
     }
+
+    public void requestCancel() {
+        this.status.validateNext(OrderStatus.CANCEL_REQUESTED);
+        this.previousStatus = this.status;
+        this.status = OrderStatus.CANCEL_REQUESTED;
+    }
+
+    public void rejectCancelRequest() {
+        this.status.validateNext(this.previousStatus);
+        this.status = this.previousStatus; // 이전 상태 복구
+        this.previousStatus = null;
+    }
+
 }

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
@@ -1,0 +1,111 @@
+package com.firstlogistics.orderservice.domain.entity;
+
+import com.firstlogistics.orderservice.domain.enums.OrderStatus;
+import com.firstlogistics.orderservice.domain.exception.OrderErrorCode;
+import com.firstlogistics.orderservice.domain.exception.OrderException;
+import com.firstlogistics.orderservice.domain.vo.Money;
+import com.firstlogistics.orderservice.domain.vo.OrderId;
+import com.firstlogistics.orderservice.domain.vo.Receiver;
+import com.firstlogistics.orderservice.domain.vo.Supplier;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order {
+    private OrderId id;
+    private Supplier supplier;
+    private Receiver receiver;
+    private UUID deliveryId;
+    private OrderStatus status;
+    private Money totalAmount;
+    private LocalDateTime dueDate;
+    private String requestMemo;
+    private List<OrderItem> orderItems;
+
+    public static Order create(
+            UUID supplierCompanyId,
+            UUID supplierManagerId,
+            UUID receiverCompanyId,
+            UUID receiverManagerId,
+            LocalDateTime dueDate,
+            String requestMemo,
+            List<OrderItem> items
+    ) {
+        Order order = new Order();
+        order.id = OrderId.of();
+        order.supplier = Supplier.of(supplierCompanyId, supplierManagerId);
+        order.receiver = Receiver.of(receiverCompanyId, receiverManagerId);
+        order.dueDate = dueDate;
+        order.requestMemo = requestMemo;
+        order.status = OrderStatus.PENDING;
+
+        order.setOrderItems(items);
+        order.calculateTotalAmount();
+
+        return order;
+    }
+
+    private void setOrderItems(List<OrderItem> orderItems) {
+        // 주문 상세 존재 여부 체크
+        if (orderItems == null || orderItems.isEmpty()) {
+            throw new OrderException(OrderErrorCode.ORDER_ITEM_NOT_EXIST);
+        }
+
+        // 주문 가능한 상품인지 체크?
+
+        this.orderItems = new ArrayList<>();
+        orderItems.forEach(this::addOrderItem);
+    }
+
+    private void addOrderItem(OrderItem item) {
+        // 개별 검증 로직 추가
+        orderItems.add(item);
+    }
+
+    private void calculateTotalAmount() {
+        this.totalAmount = Money.of(orderItems.stream()
+                .mapToLong(x -> x.getSubTotal().getAmount())
+                .sum());
+    }
+
+    public void accept() {
+        this.status.validateNext(OrderStatus.ACCEPTED);
+        this.status = OrderStatus.ACCEPTED;
+    }
+
+    public void assignDelivery(UUID deliveryId) {
+        // 이미 배송이 할당된 경우
+        if (this.deliveryId != null) {
+            throw new OrderException(OrderErrorCode.DELIVERY_ALREADY_ASSIGNED);
+        }
+
+        // 주문 승인 상태에서만 배송 할당 가능
+        if (!status.equals(OrderStatus.ACCEPTED)) {
+            throw new OrderException(OrderErrorCode.INVALID_ORDER_STATUS_FOR_DELIVERY);
+        }
+
+        this.deliveryId = deliveryId;
+    }
+
+    public void startShipping() {
+        this.status.validateNext(OrderStatus.SHIPPING);
+        this.status = OrderStatus.SHIPPING;
+    }
+
+    public void complete() {
+        this.status.validateNext(OrderStatus.COMPLETED);
+        this.status = OrderStatus.COMPLETED;
+    }
+
+    public void cancel() {
+        this.status.validateNext(OrderStatus.CANCELLED);
+        this.status = OrderStatus.CANCELLED;
+    }
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
@@ -147,12 +147,20 @@ public class Order {
     }
 
     public void requestCancel() {
+        // 이미 취소 요청 or 취소 된 상태인 경우
+        if (this.status == OrderStatus.CANCEL_REQUESTED || this.status == OrderStatus.CANCELLED) {
+            throw new OrderException(OrderErrorCode.ALREADY_CANCEL_REQUESTED);
+        }
         this.status.validateNext(OrderStatus.CANCEL_REQUESTED);
         this.previousStatus = this.status;
         this.status = OrderStatus.CANCEL_REQUESTED;
     }
 
     public void rejectCancelRequest() {
+        // 취소 요청 상태에서만 가능
+        if (this.status != OrderStatus.CANCEL_REQUESTED || this.previousStatus == null) {
+            throw new OrderException(OrderErrorCode.CANNOT_REJECT_CANCEL);
+        }
         this.status.validateNext(this.previousStatus);
         this.status = this.previousStatus; // 이전 상태 복구
         this.previousStatus = null;

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
@@ -8,6 +8,7 @@ import com.firstlogistics.orderservice.domain.vo.OrderId;
 import com.firstlogistics.orderservice.domain.vo.Receiver;
 import com.firstlogistics.orderservice.domain.vo.Supplier;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,7 +18,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Order {
     private OrderId id;
     private Supplier supplier;
@@ -36,23 +37,27 @@ public class Order {
             UUID receiverManagerId,
             LocalDateTime dueDate,
             String requestMemo,
-            List<OrderItem> items
+            List<OrderItem> items // 추후 DTO로 수정
     ) {
-        Order order = new Order();
-        order.id = OrderId.of();
-        order.supplier = Supplier.of(supplierCompanyId, supplierManagerId);
-        order.receiver = Receiver.of(receiverCompanyId, receiverManagerId);
-        order.dueDate = dueDate;
-        order.requestMemo = requestMemo;
-        order.status = OrderStatus.PENDING;
+        Order order = new Order(
+                OrderId.of(),
+                Supplier.of(supplierCompanyId, supplierManagerId),
+                Receiver.of(receiverCompanyId, receiverManagerId),
+                null,
+                OrderStatus.PENDING,
+                Money.of(0L),
+                dueDate,
+                requestMemo,
+                new ArrayList<>()
+        );
 
-        order.setOrderItems(items);
+        order.initOrderItems(items);
         order.calculateTotalAmount();
 
         return order;
     }
 
-    private void setOrderItems(List<OrderItem> orderItems) {
+    private void initOrderItems(List<OrderItem> orderItems) {
         // 주문 상세 존재 여부 체크
         if (orderItems == null || orderItems.isEmpty()) {
             throw new OrderException(OrderErrorCode.ORDER_ITEM_NOT_EXIST);
@@ -66,12 +71,18 @@ public class Order {
 
     private void addOrderItem(OrderItem item) {
         // 개별 검증 로직 추가
-        orderItems.add(item);
+        orderItems.add(OrderItem.create(
+                this.id,
+                item.getProductId(),
+                item.getProductName(),
+                item.getUnitPrice(),
+                item.getQuantity()
+        ));
     }
 
     private void calculateTotalAmount() {
         this.totalAmount = Money.of(orderItems.stream()
-                .mapToLong(x -> x.getSubTotal().amount())
+                .mapToLong(item -> item.getSubTotal().amount())
                 .sum());
     }
 

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
@@ -108,17 +108,18 @@ public class Order {
     }
 
     public void assignDelivery(UUID deliveryId) {
+        if (deliveryId == null) {
+            throw new OrderException(OrderErrorCode.INVALID_DELIVERY_ID);
+        }
+
         // 이미 배송이 할당된 경우
         if (this.deliveryId != null) {
             throw new OrderException(OrderErrorCode.DELIVERY_ALREADY_ASSIGNED);
         }
 
-        // 주문 승인 상태에서만 배송 할당 가능
-        if (!status.equals(OrderStatus.ACCEPTED)) {
-            throw new OrderException(OrderErrorCode.INVALID_ORDER_STATUS_FOR_DELIVERY);
-        }
-
+        this.status.validateNext(OrderStatus.READY);
         this.deliveryId = deliveryId;
+        this.status = OrderStatus.READY;
     }
 
     public void startShipping() {

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
@@ -100,6 +100,14 @@ public class Order {
 
         // 취소 요청 상태에서는 이전 상태 업데이트
         if (this.status == OrderStatus.CANCEL_REQUESTED) {
+
+            // 취소 요청 상태에서 재고 예약 실패 시 취소 상태로 변경
+            if(!isSuccess) {
+                this.status = OrderStatus.CANCELLED;
+                this.previousStatus = null;
+                return;
+            }
+
             this.previousStatus.validateNext(resultStatus);
             this.previousStatus = resultStatus;
             return;

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
@@ -10,12 +10,9 @@ import com.firstlogistics.orderservice.domain.vo.Supplier;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -29,6 +26,8 @@ public class Order {
     private String requestMemo;
     private OrderStatus status;
     private OrderStatus previousStatus;
+
+    @Getter(AccessLevel.NONE)
     private List<OrderItem> orderItems;
 
     public static Order create(
@@ -59,9 +58,17 @@ public class Order {
         return order;
     }
 
+    // 외부에서 리스트 수정 못하도록 읽기 전용으로 반환
+    public List<OrderItem> getOrderItems() {
+        return Collections.unmodifiableList(orderItems);
+    }
+
     private void initOrderItems(List<OrderItem> orderItems) {
         // 주문 상세 존재 여부 체크
         if (orderItems == null || orderItems.isEmpty()) {
+            throw new OrderException(OrderErrorCode.ORDER_ITEM_NOT_EXIST);
+        }
+        if (orderItems.stream().anyMatch(Objects::isNull)) {
             throw new OrderException(OrderErrorCode.ORDER_ITEM_NOT_EXIST);
         }
 

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
@@ -12,7 +12,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/OrderItem.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/OrderItem.java
@@ -1,0 +1,44 @@
+package com.firstlogistics.orderservice.domain.entity;
+
+import com.firstlogistics.orderservice.domain.vo.Money;
+import com.firstlogistics.orderservice.domain.vo.OrderId;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderItem {
+    private UUID id;
+    private OrderId orderId;
+    private UUID productId;
+    private String productName;
+    private Money unitPrice;
+    private int quantity;
+    private Money subTotal;
+
+    public static OrderItem create(
+            OrderId orderId,
+            UUID productId,
+            String productName,
+            Long unitPrice,
+            int quantity
+    ) {
+        OrderItem item = new OrderItem();
+        item.id = UUID.randomUUID();
+        item.orderId = orderId;
+        item.productId = productId;
+        item.productName = productName;
+        item.unitPrice = Money.of(unitPrice);
+        item.quantity = quantity;
+        item.calculateSubTotal();
+
+        return item;
+    }
+
+    private void calculateSubTotal() {
+        this.subTotal = unitPrice.multiply(quantity);
+    }
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/OrderItem.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/OrderItem.java
@@ -3,13 +3,14 @@ package com.firstlogistics.orderservice.domain.entity;
 import com.firstlogistics.orderservice.domain.vo.Money;
 import com.firstlogistics.orderservice.domain.vo.OrderId;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.UUID;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class OrderItem {
     private UUID id;
     private OrderId orderId;
@@ -19,26 +20,21 @@ public class OrderItem {
     private int quantity;
     private Money subTotal;
 
-    public static OrderItem create(
+    static OrderItem create(
             OrderId orderId,
             UUID productId,
             String productName,
-            Long unitPrice,
+            Money unitPrice,
             int quantity
     ) {
-        OrderItem item = new OrderItem();
-        item.id = UUID.randomUUID();
-        item.orderId = orderId;
-        item.productId = productId;
-        item.productName = productName;
-        item.unitPrice = Money.of(unitPrice);
-        item.quantity = quantity;
-        item.calculateSubTotal();
-
-        return item;
-    }
-
-    private void calculateSubTotal() {
-        this.subTotal = unitPrice.multiply(quantity);
+        return new OrderItem(
+                UUID.randomUUID(),
+                orderId,
+                productId,
+                productName,
+                unitPrice,
+                quantity,
+                unitPrice.multiply(quantity)
+        );
     }
 }

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/OrderItem.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/OrderItem.java
@@ -5,7 +5,6 @@ import com.firstlogistics.orderservice.domain.vo.OrderId;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.util.UUID;
 

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/enums/OrderStatus.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/enums/OrderStatus.java
@@ -1,0 +1,30 @@
+package com.firstlogistics.orderservice.domain.enums;
+
+import com.firstlogistics.orderservice.domain.exception.OrderErrorCode;
+import com.firstlogistics.orderservice.domain.exception.OrderException;
+
+import java.util.Map;
+import java.util.Set;
+
+public enum OrderStatus {
+    PENDING,    // 주문 접수
+    ACCEPTED,   // 주문 승인
+    SHIPPING,   // 배송 중
+    COMPLETED,  // 배송 완료
+    CANCELLED;   // 주문 취소
+
+    // 상태 전이 Map
+    private static final Map<OrderStatus, Set<OrderStatus>> transitions = Map.of(
+            PENDING, Set.of(ACCEPTED, CANCELLED),
+            ACCEPTED, Set.of(SHIPPING, CANCELLED),
+            SHIPPING, Set.of(COMPLETED),
+            COMPLETED, Set.of(),
+            CANCELLED, Set.of()
+    );
+
+    public void validateNext(OrderStatus next) {
+        if (!transitions.getOrDefault(this, Set.of()).contains(next)) {
+            throw new OrderException(OrderErrorCode.INVALID_ORDER_STATUS);
+        }
+    }
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/enums/OrderStatus.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/enums/OrderStatus.java
@@ -7,18 +7,22 @@ import java.util.Map;
 import java.util.Set;
 
 public enum OrderStatus {
-    PENDING,    // 주문 접수
-    ACCEPTED,   // 주문 승인
-    SHIPPING,   // 배송 중
-    COMPLETED,  // 배송 완료
-    CANCELLED;   // 주문 취소
+    PENDING,            // 주문 접수
+    RESERVED,           // 주문 예약 (재고 예약 완료)
+    ACCEPTED,           // 주문 승인 (관리자 승인)
+    SHIPPING,           // 배송 중
+    COMPLETED,          // 배송 완료
+    CANCEL_REQUESTED,   // 주문 취소 요청
+    CANCELLED;          // 주문 취소
 
     // 상태 전이 Map
     private static final Map<OrderStatus, Set<OrderStatus>> transitions = Map.of(
-            PENDING, Set.of(ACCEPTED, CANCELLED),
-            ACCEPTED, Set.of(SHIPPING, CANCELLED),
+            PENDING, Set.of(RESERVED, CANCELLED),
+            RESERVED, Set.of(ACCEPTED, CANCEL_REQUESTED, CANCELLED),
+            ACCEPTED, Set.of(SHIPPING),
             SHIPPING, Set.of(COMPLETED),
             COMPLETED, Set.of(),
+            CANCEL_REQUESTED, Set.of(CANCELLED, PENDING, RESERVED),
             CANCELLED, Set.of()
     );
 

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/enums/OrderStatus.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/enums/OrderStatus.java
@@ -18,7 +18,7 @@ public enum OrderStatus {
 
     // 상태 전이 Map
     private static final Map<OrderStatus, Set<OrderStatus>> transitions = Map.of(
-            PENDING, Set.of(RESERVED, CANCELLED),
+            PENDING, Set.of(RESERVED, CANCEL_REQUESTED, CANCELLED),
             RESERVED, Set.of(ACCEPTED, CANCEL_REQUESTED, CANCELLED),
             ACCEPTED, Set.of(READY),
             READY, Set.of(SHIPPING),
@@ -29,6 +29,7 @@ public enum OrderStatus {
     );
 
     public void validateNext(OrderStatus next) {
+        if (this == next) return;
         if (!transitions.getOrDefault(this, Set.of()).contains(next)) {
             throw new OrderException(OrderErrorCode.INVALID_ORDER_STATUS);
         }

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/enums/OrderStatus.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/enums/OrderStatus.java
@@ -10,6 +10,7 @@ public enum OrderStatus {
     PENDING,            // 주문 접수
     RESERVED,           // 주문 예약 (재고 예약 완료)
     ACCEPTED,           // 주문 승인 (관리자 승인)
+    READY,              // 배송 준비 (배송 ID 할당)
     SHIPPING,           // 배송 중
     COMPLETED,          // 배송 완료
     CANCEL_REQUESTED,   // 주문 취소 요청
@@ -19,7 +20,8 @@ public enum OrderStatus {
     private static final Map<OrderStatus, Set<OrderStatus>> transitions = Map.of(
             PENDING, Set.of(RESERVED, CANCELLED),
             RESERVED, Set.of(ACCEPTED, CANCEL_REQUESTED, CANCELLED),
-            ACCEPTED, Set.of(SHIPPING),
+            ACCEPTED, Set.of(READY),
+            READY, Set.of(SHIPPING),
             SHIPPING, Set.of(COMPLETED),
             COMPLETED, Set.of(),
             CANCEL_REQUESTED, Set.of(CANCELLED, PENDING, RESERVED),

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/exception/OrderErrorCode.java
@@ -12,7 +12,8 @@ public enum OrderErrorCode implements ErrorCode {
     ORDER_ITEM_NOT_EXIST(HttpStatus.BAD_REQUEST, "ORD001", "주문 상품은 1개 이상이어야 합니다."),
     INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "ORD002", "허용되지 않은 주문 상태 변경입니다."),
     DELIVERY_ALREADY_ASSIGNED(HttpStatus.BAD_REQUEST, "ORD003", "이미 배송이 할당된 주문입니다."),
-    INVALID_DELIVERY_ID(HttpStatus.BAD_REQUEST, "ORD004", "배송 할당을 위해서는 유효한 배송 ID가 필수입니다.");
+    INVALID_DELIVERY_ID(HttpStatus.BAD_REQUEST, "ORD004", "배송 할당을 위해서는 유효한 배송 ID가 필수입니다."),
+    INVALID_MONEY_AMOUNT(HttpStatus.BAD_REQUEST, "ORD005", "금액은 null이거나 0보다 작을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/exception/OrderErrorCode.java
@@ -13,7 +13,9 @@ public enum OrderErrorCode implements ErrorCode {
     INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "ORD002", "허용되지 않은 주문 상태 변경입니다."),
     DELIVERY_ALREADY_ASSIGNED(HttpStatus.BAD_REQUEST, "ORD003", "이미 배송이 할당된 주문입니다."),
     INVALID_DELIVERY_ID(HttpStatus.BAD_REQUEST, "ORD004", "배송 할당을 위해서는 유효한 배송 ID가 필수입니다."),
-    INVALID_MONEY_AMOUNT(HttpStatus.BAD_REQUEST, "ORD005", "금액은 null이거나 0보다 작을 수 없습니다.");
+    INVALID_MONEY_AMOUNT(HttpStatus.BAD_REQUEST, "ORD005", "금액은 null이거나 0보다 작을 수 없습니다."),
+    ALREADY_CANCEL_REQUESTED(HttpStatus.BAD_REQUEST, "ORD006", "이미 취소 요청된 주문입니다."),
+    CANNOT_REJECT_CANCEL(HttpStatus.BAD_REQUEST, "ORD007", "취소 요청 상태 주문이 아닙니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/exception/OrderErrorCode.java
@@ -12,7 +12,7 @@ public enum OrderErrorCode implements ErrorCode {
     ORDER_ITEM_NOT_EXIST(HttpStatus.BAD_REQUEST, "ORD001", "주문 상품은 1개 이상이어야 합니다."),
     INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "ORD002", "허용되지 않은 주문 상태 변경입니다."),
     DELIVERY_ALREADY_ASSIGNED(HttpStatus.BAD_REQUEST, "ORD003", "이미 배송이 할당된 주문입니다."),
-    INVALID_ORDER_STATUS_FOR_DELIVERY(HttpStatus.BAD_REQUEST, "ORD004", "배송은 승인된 주문에서만 가능합니다.");
+    INVALID_DELIVERY_ID(HttpStatus.BAD_REQUEST, "ORD004", "배송 할당을 위해서는 유효한 배송 ID가 필수입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/exception/OrderErrorCode.java
@@ -1,0 +1,20 @@
+package com.firstlogistics.orderservice.domain.exception;
+
+import common.response.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderErrorCode implements ErrorCode {
+
+    ORDER_ITEM_NOT_EXIST(HttpStatus.BAD_REQUEST, "ORD_001", "주문 상품은 1개 이상이어야 합니다."),
+    INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "ORD_002", "허용되지 않은 주문 상태 변경입니다."),
+    DELIVERY_ALREADY_ASSIGNED(HttpStatus.BAD_REQUEST, "ORD_003", "이미 배송이 할당된 주문입니다."),
+    INVALID_ORDER_STATUS_FOR_DELIVERY(HttpStatus.BAD_REQUEST, "ORD_004", "배송은 승인된 주문에서만 가능합니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/exception/OrderErrorCode.java
@@ -9,10 +9,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum OrderErrorCode implements ErrorCode {
 
-    ORDER_ITEM_NOT_EXIST(HttpStatus.BAD_REQUEST, "ORD_001", "주문 상품은 1개 이상이어야 합니다."),
-    INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "ORD_002", "허용되지 않은 주문 상태 변경입니다."),
-    DELIVERY_ALREADY_ASSIGNED(HttpStatus.BAD_REQUEST, "ORD_003", "이미 배송이 할당된 주문입니다."),
-    INVALID_ORDER_STATUS_FOR_DELIVERY(HttpStatus.BAD_REQUEST, "ORD_004", "배송은 승인된 주문에서만 가능합니다.");
+    ORDER_ITEM_NOT_EXIST(HttpStatus.BAD_REQUEST, "ORD001", "주문 상품은 1개 이상이어야 합니다."),
+    INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "ORD002", "허용되지 않은 주문 상태 변경입니다."),
+    DELIVERY_ALREADY_ASSIGNED(HttpStatus.BAD_REQUEST, "ORD003", "이미 배송이 할당된 주문입니다."),
+    INVALID_ORDER_STATUS_FOR_DELIVERY(HttpStatus.BAD_REQUEST, "ORD004", "배송은 승인된 주문에서만 가능합니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/exception/OrderException.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/exception/OrderException.java
@@ -1,0 +1,10 @@
+package com.firstlogistics.orderservice.domain.exception;
+
+import common.exception.BaseException;
+
+public class OrderException extends BaseException {
+
+    public OrderException(OrderErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/repository/OrderRepository.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/repository/OrderRepository.java
@@ -1,0 +1,11 @@
+package com.firstlogistics.orderservice.domain.repository;
+
+import com.firstlogistics.orderservice.domain.entity.Order;
+import com.firstlogistics.orderservice.domain.vo.OrderId;
+
+import java.util.Optional;
+
+public interface OrderRepository {
+    Order save(Order order);
+    Optional<Order> findById(OrderId id);
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/vo/Money.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/vo/Money.java
@@ -1,8 +1,20 @@
 package com.firstlogistics.orderservice.domain.vo;
 
+import com.firstlogistics.orderservice.domain.exception.OrderErrorCode;
+import com.firstlogistics.orderservice.domain.exception.OrderException;
+
 public record Money(
         Long amount
 ) {
+    public Money {
+        if (amount == null) {
+            throw new OrderException(OrderErrorCode.INVALID_MONEY_AMOUNT);
+        }
+        if (amount < 0) {
+            throw new OrderException(OrderErrorCode.INVALID_MONEY_AMOUNT);
+        }
+    }
+
     public static Money of(Long amount) {
         return new Money(amount);
     }

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/vo/Money.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/vo/Money.java
@@ -1,16 +1,8 @@
 package com.firstlogistics.orderservice.domain.vo;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Money {
-    private Long amount;
-
+public record Money(
+        Long amount
+) {
     public static Money of(Long amount) {
         return new Money(amount);
     }

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/vo/Money.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/vo/Money.java
@@ -1,0 +1,25 @@
+package com.firstlogistics.orderservice.domain.vo;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Money {
+    private Long amount;
+
+    public static Money of(Long amount) {
+        return new Money(amount);
+    }
+
+    public Money add(Money money) {
+        return new Money(this.amount + money.amount);
+    }
+
+    public Money multiply(int quantity) {
+        return new Money(this.amount * quantity);
+    }
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/vo/OrderId.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/vo/OrderId.java
@@ -1,16 +1,10 @@
 package com.firstlogistics.orderservice.domain.vo;
 
-import lombok.*;
-
 import java.util.UUID;
 
-@Getter
-@EqualsAndHashCode
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
-public class OrderId {
-    private UUID id;
-
+public record OrderId(
+        UUID id
+) {
     public static OrderId of() {
         return OrderId.of(UUID.randomUUID());
     }

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/vo/OrderId.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/vo/OrderId.java
@@ -1,0 +1,21 @@
+package com.firstlogistics.orderservice.domain.vo;
+
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderId {
+    private UUID id;
+
+    public static OrderId of() {
+        return OrderId.of(UUID.randomUUID());
+    }
+
+    public static OrderId of(UUID id) {
+        return new OrderId(id);
+    }
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/vo/Receiver.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/vo/Receiver.java
@@ -1,0 +1,20 @@
+package com.firstlogistics.orderservice.domain.vo;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Receiver {
+    private UUID companyId;
+    private UUID managerId;
+
+    public static Receiver of(UUID companyId, UUID managerId) {
+        return new Receiver(companyId, managerId);
+    }
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/vo/Receiver.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/vo/Receiver.java
@@ -1,19 +1,11 @@
 package com.firstlogistics.orderservice.domain.vo;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 import java.util.UUID;
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Receiver {
-    private UUID companyId;
-    private UUID managerId;
-
+public record Receiver(
+        UUID companyId,
+        UUID managerId
+) {
     public static Receiver of(UUID companyId, UUID managerId) {
         return new Receiver(companyId, managerId);
     }

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/vo/Supplier.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/vo/Supplier.java
@@ -1,0 +1,20 @@
+package com.firstlogistics.orderservice.domain.vo;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Supplier {
+    private UUID companyId;
+    private UUID managerId;
+
+    public static Supplier of(UUID companyId, UUID managerId) {
+        return new Supplier(companyId, managerId);
+    }
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/vo/Supplier.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/vo/Supplier.java
@@ -1,19 +1,11 @@
 package com.firstlogistics.orderservice.domain.vo;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 import java.util.UUID;
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Supplier {
-    private UUID companyId;
-    private UUID managerId;
-
+public record Supplier(
+        UUID companyId,
+        UUID managerId
+) {
     public static Supplier of(UUID companyId, UUID managerId) {
         return new Supplier(companyId, managerId);
     }


### PR DESCRIPTION
### 📌 관련 이슈
- close #22 

### 💡 작업 내용
- 주문 도메인 엔티티, VO, ENUM 추가
  - 도메인 로직 메서드 구현
- `OrderErrorCode`, `OrderException` 추가
- `OrderRepository` 인터페이스 추가

### 🔍 변경 이유
- 

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full order lifecycle with enforced state transitions (create, reserve, accept, assign delivery, start shipping, complete, cancel/request/reject).
  * Order items with unit price, quantity, subtotal and automatic total calculation; rejects empty/invalid items.
  * Value objects: Money (with validation), OrderId, Supplier, Receiver.
  * Repository contract for persisting and retrieving orders.
  * Standardized order error codes for validation and state errors.

* **Chores**
  * H2 database added as a runtime dependency for initial builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->