### PR TITLE
fix: 주문 테스트 코드 빌드 오류 수정

### DIFF
--- a/order-service/src/test/java/com/firstlogistics/orderservice/application/OrderServiceTest.java
+++ b/order-service/src/test/java/com/firstlogistics/orderservice/application/OrderServiceTest.java
@@ -40,7 +40,7 @@ class OrderServiceTest {
         CreateOrderCommand command = new CreateOrderCommand(
                 UUID.randomUUID(), UUID.randomUUID(),
                 UUID.randomUUID(), UUID.randomUUID(),
-                "서울시 강남구", LocalDateTime.now().plusDays(1),
+                "서울시 강남구", "상세주소", LocalDateTime.now().plusDays(1),
                 "빨리 배송해주세요", List.of(item)
         );
 
@@ -59,7 +59,7 @@ class OrderServiceTest {
         CreateOrderCommand command = new CreateOrderCommand(
                 UUID.randomUUID(), UUID.randomUUID(),
                 UUID.randomUUID(), UUID.randomUUID(),
-                "서울시 강남구", LocalDateTime.now().plusDays(1),
+                "서울시 강남구", "상세주소", LocalDateTime.now().plusDays(1),
                 "메모", List.of() // 빈 리스트
         );
 

--- a/order-service/src/test/java/com/firstlogistics/orderservice/infrastructure/persistence/jpa/OrderMapperTest.java
+++ b/order-service/src/test/java/com/firstlogistics/orderservice/infrastructure/persistence/jpa/OrderMapperTest.java
@@ -46,6 +46,7 @@ class OrderMapperTest {
                 UUID.randomUUID(), // receiverManagerId
                 UUID.randomUUID(), // deliveryId
                 "배송 주소",
+                "상세 주소",
                 30000L,            // totalAmount
                 LocalDateTime.now().plusDays(3),
                 "배송 메시지",


### PR DESCRIPTION
### 📌 관련 이슈
- close #72 
- 
### 💡 작업 내용
- 주문 생성 테스트 & OrderMapperTest에 주문 상세주소 필드 반영

### 🔍 변경 이유
- 주문 필드 추가 후 테스트 코드 수정 누락으로 인한 빌드 오류 수정

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * 주문 생성 테스트에서 주소 상세 정보 필드를 포함하도록 테스트 데이터 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->