### PR TITLE
feat: 주문 취소 관련 기능 구현

### DIFF
--- a/order-service/src/main/java/com/firstlogistics/orderservice/application/OrderCommandService.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/application/OrderCommandService.java
@@ -87,6 +87,16 @@ public class OrderCommandService {
         return order.getStatus().name();
     }
 
+    @Transactional
+    public String requestCancel(UUID userId, UUID orderId) {
+        Order order = getOrder(orderId);
+        order.requestCancel();
+
+        orderRepository.save(order);
+
+        return order.getStatus().name();
+    }
+
     private Order getOrder(UUID orderId) {
         return orderRepository.findById(OrderId.of(orderId))
                 .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));

--- a/order-service/src/main/java/com/firstlogistics/orderservice/application/OrderCommandService.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/application/OrderCommandService.java
@@ -91,6 +91,16 @@ public class OrderCommandService {
         return processCancellation(userId, orderId);
     }
 
+    @Transactional
+    public String rejectCancelRequest(UUID userId, UUID orderId) {
+        Order order = getOrder(orderId);
+        order.rejectCancelRequest();
+
+        orderRepository.save(order);
+
+        return order.getStatus().name();
+    }
+
     private Order getOrder(UUID orderId) {
         return orderRepository.findById(OrderId.of(orderId))
                 .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));

--- a/order-service/src/main/java/com/firstlogistics/orderservice/application/OrderCommandService.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/application/OrderCommandService.java
@@ -63,28 +63,16 @@ public class OrderCommandService {
         return order.getStatus().name();
     }
 
+    // 주문 거절로 인한 취소
     @Transactional
     public String rejectOrder(UUID userId, UUID orderId) {
-        Order order = getOrder(orderId);
-        order.cancel();
-
-        orderRepository.save(order);
-
-        Events.trigger(OrderCancelledEvent.from(order));
-
-        return order.getStatus().name();
+        return processCancellation(userId, orderId);
     }
 
+    // 관리자가 직접 주문 취소
     @Transactional
     public String cancelOrder(UUID userId, UUID orderId) {
-        Order order  = getOrder(orderId);
-        order.cancel();
-
-        orderRepository.save(order);
-
-        Events.trigger(OrderCancelledEvent.from(order));
-
-        return order.getStatus().name();
+        return processCancellation(userId, orderId);
     }
 
     @Transactional
@@ -97,8 +85,25 @@ public class OrderCommandService {
         return order.getStatus().name();
     }
 
+    // 주문 취소 요청 승인으로 인한 취소
+    @Transactional
+    public String approveCancelRequest(UUID userId, UUID orderId) {
+        return processCancellation(userId, orderId);
+    }
+
     private Order getOrder(UUID orderId) {
         return orderRepository.findById(OrderId.of(orderId))
                 .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
+    }
+
+    private String processCancellation(UUID userId, UUID orderId) {
+        Order order  = getOrder(orderId);
+        order.cancel();
+
+        orderRepository.save(order);
+
+        Events.trigger(OrderCancelledEvent.from(order));
+
+        return order.getStatus().name();
     }
 }

--- a/order-service/src/main/java/com/firstlogistics/orderservice/application/OrderCommandService.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/application/OrderCommandService.java
@@ -75,6 +75,18 @@ public class OrderCommandService {
         return order.getStatus().name();
     }
 
+    @Transactional
+    public String cancelOrder(UUID userId, UUID orderId) {
+        Order order  = getOrder(orderId);
+        order.cancel();
+
+        orderRepository.save(order);
+
+        Events.trigger(OrderCancelledEvent.from(order));
+
+        return order.getStatus().name();
+    }
+
     private Order getOrder(UUID orderId) {
         return orderRepository.findById(OrderId.of(orderId))
                 .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));

--- a/order-service/src/main/java/com/firstlogistics/orderservice/application/OrderCommandService.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/application/OrderCommandService.java
@@ -2,6 +2,7 @@ package com.firstlogistics.orderservice.application;
 
 import com.firstlogistics.orderservice.application.dto.CreateOrderCommand;
 import com.firstlogistics.orderservice.domain.entity.Order;
+import com.firstlogistics.orderservice.domain.enums.OrderCancelType;
 import com.firstlogistics.orderservice.domain.event.OrderAcceptedEvent;
 import com.firstlogistics.orderservice.domain.event.OrderCancelledEvent;
 import com.firstlogistics.orderservice.domain.event.OrderCreatedEvent;
@@ -66,13 +67,13 @@ public class OrderCommandService {
     // 주문 거절로 인한 취소
     @Transactional
     public String rejectOrder(UUID userId, UUID orderId) {
-        return processCancellation(userId, orderId);
+        return processCancellation(userId, orderId, OrderCancelType.SUPPLIER_CANCEL);
     }
 
     // 관리자가 직접 주문 취소
     @Transactional
     public String cancelOrder(UUID userId, UUID orderId) {
-        return processCancellation(userId, orderId);
+        return processCancellation(userId, orderId, OrderCancelType.ADMIN_CANCEL);
     }
 
     @Transactional
@@ -88,7 +89,7 @@ public class OrderCommandService {
     // 주문 취소 요청 승인으로 인한 취소
     @Transactional
     public String approveCancelRequest(UUID userId, UUID orderId) {
-        return processCancellation(userId, orderId);
+        return processCancellation(userId, orderId, OrderCancelType.ORDERER_REQUEST);
     }
 
     @Transactional
@@ -106,9 +107,9 @@ public class OrderCommandService {
                 .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
     }
 
-    private String processCancellation(UUID userId, UUID orderId) {
+    private String processCancellation(UUID userId, UUID orderId, OrderCancelType cancelType) {
         Order order  = getOrder(orderId);
-        order.cancel();
+        order.cancel(cancelType);
 
         orderRepository.save(order);
 

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
@@ -220,6 +220,8 @@ public class Order {
     }
 
     public void requestCancel() {
+        // TODO: 로그인한 사용자가 주문한 사용자와 같은지 확인
+
         // 이미 취소 요청 or 취소 된 상태인 경우
         if (this.status == OrderStatus.CANCEL_REQUESTED || this.status == OrderStatus.CANCELLED) {
             throw new OrderException(OrderErrorCode.ALREADY_CANCEL_REQUESTED);

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
@@ -232,6 +232,8 @@ public class Order {
     }
 
     public void rejectCancelRequest() {
+        // TODO: 관리자 권한 확인
+
         // 취소 요청 상태에서만 가능
         if (this.status != OrderStatus.CANCEL_REQUESTED || this.previousStatus == null) {
             throw new OrderException(OrderErrorCode.CANNOT_REJECT_CANCEL);

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
@@ -1,5 +1,6 @@
 package com.firstlogistics.orderservice.domain.entity;
 
+import com.firstlogistics.orderservice.domain.enums.OrderCancelType;
 import com.firstlogistics.orderservice.domain.enums.OrderStatus;
 import com.firstlogistics.orderservice.domain.exception.OrderErrorCode;
 import com.firstlogistics.orderservice.domain.exception.OrderException;
@@ -33,6 +34,7 @@ public class Order {
     private String requestMemo;
     private OrderStatus status;
     private OrderStatus previousStatus;
+    private OrderCancelType cancelType;
     private LocalDateTime orderedAt;
 
     @Getter(AccessLevel.NONE)
@@ -64,6 +66,7 @@ public class Order {
                 OrderStatus.PENDING,
                 null,
                 null,
+                null,
                 new ArrayList<>(),
                 null
         );
@@ -91,6 +94,7 @@ public class Order {
             String requestMemo,
             OrderStatus status,
             OrderStatus previousStatus,
+            OrderCancelType cancelType,
             LocalDateTime orderedAt,
             List<OrderItem> orderItems,
             Long version
@@ -106,6 +110,7 @@ public class Order {
                 requestMemo,
                 status,
                 previousStatus,
+                cancelType,
                 orderedAt,
                 orderItems,
                 version

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
@@ -163,6 +163,7 @@ public class Order {
             if(!isSuccess) {
                 this.status = OrderStatus.CANCELLED;
                 this.previousStatus = null;
+                this.cancelType = OrderCancelType.STOCK_OUT;
                 return;
             }
 
@@ -212,8 +213,12 @@ public class Order {
     }
 
     // 주문 취소 / 거절 / 취소 요청 승인 (나중에 필요하면 분리)
-    public void cancel() {
+    public void cancel(OrderCancelType cancelType) {
         // TODO: 허브 관리자, 마스터 관리자, 공급 업체 담당자 권한 검증
+
+        if (cancelType == null) {
+            throw new OrderException(OrderErrorCode.CANCEL_TYPE_REQUIRED);
+        }
 
         if (this.status == OrderStatus.CANCELLED) {
             throw new OrderException(OrderErrorCode.ALREADY_CANCELLED);
@@ -222,6 +227,7 @@ public class Order {
         this.status.validateNext(OrderStatus.CANCELLED);
         this.status = OrderStatus.CANCELLED;
         this.previousStatus = null; // 취소 요청이었다면 이전 상태 초기화
+        this.cancelType = cancelType;
     }
 
     public void requestCancel() {

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/entity/Order.java
@@ -208,7 +208,7 @@ public class Order {
 
     // 주문 취소 / 거절 / 취소 요청 승인 (나중에 필요하면 분리)
     public void cancel() {
-        // TODO: 권한 검증
+        // TODO: 허브 관리자, 마스터 관리자, 공급 업체 담당자 권한 검증
 
         if (this.status == OrderStatus.CANCELLED) {
             throw new OrderException(OrderErrorCode.ALREADY_CANCELLED);

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/enums/OrderCancelType.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/enums/OrderCancelType.java
@@ -1,0 +1,19 @@
+package com.firstlogistics.orderservice.domain.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum OrderCancelType {
+    ORDERER_REQUEST("발주처 요청 취소"),
+    STOCK_OUT("재고 부족"),
+    SUPPLIER_CANCEL("공급처 취소"),
+    ADMIN_CANCEL("관리자 직권 취소"),
+    SYSTEM_ERROR("시스템 오류"),
+    ETC("기타 사유");
+
+    private final String description;
+
+    OrderCancelType(String description) {
+        this.description = description;
+    }
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/exception/OrderErrorCode.java
@@ -34,13 +34,14 @@ public enum OrderErrorCode implements ErrorCode {
     ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "ORD016", "이미 취소된 주문입니다."),
     ALREADY_CANCEL_REQUESTED(HttpStatus.BAD_REQUEST, "ORD017", "이미 취소 요청된 주문입니다."),
     CANNOT_REJECT_CANCEL(HttpStatus.BAD_REQUEST, "ORD018", "취소 요청 상태 주문이 아닙니다."),
+    CANCEL_TYPE_REQUIRED(HttpStatus.BAD_REQUEST, "ORD019", "주문 취소 시 취소 사유는 필수입니다."),
 
     // 배송 할당 관련
-    INVALID_DELIVERY_ID(HttpStatus.BAD_REQUEST, "ORD019", "배송 할당을 위해서는 유효한 배송 ID가 필수입니다."),
-    DELIVERY_ALREADY_ASSIGNED(HttpStatus.BAD_REQUEST, "ORD020", "이미 배송이 할당된 주문입니다."),
+    INVALID_DELIVERY_ID(HttpStatus.BAD_REQUEST, "ORD020", "배송 할당을 위해서는 유효한 배송 ID가 필수입니다."),
+    DELIVERY_ALREADY_ASSIGNED(HttpStatus.BAD_REQUEST, "ORD021", "이미 배송이 할당된 주문입니다."),
 
     // 동시성 제어
-    ALREADY_PROCESSING(HttpStatus.CONFLICT, "ORD021", "현재 다른 요청이 처리 중입니다. 잠시 후 다시 시도해주세요.");
+    ALREADY_PROCESSING(HttpStatus.CONFLICT, "ORD022", "현재 다른 요청이 처리 중입니다. 잠시 후 다시 시도해주세요.");
 
     private final HttpStatus status;
     private final String code;

--- a/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/persistence/jpa/OrderJpaEntity.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/persistence/jpa/OrderJpaEntity.java
@@ -1,5 +1,6 @@
 package com.firstlogistics.orderservice.infrastructure.persistence.jpa;
 
+import com.firstlogistics.orderservice.domain.enums.OrderCancelType;
 import com.firstlogistics.orderservice.domain.enums.OrderStatus;
 import common.jpa.entity.BaseAuditEntity;
 import jakarta.persistence.CascadeType;
@@ -71,6 +72,10 @@ public class OrderJpaEntity extends BaseAuditEntity {
     @Enumerated(EnumType.STRING)
     @Column(length = 20, nullable = true)
     private OrderStatus previousStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = true)
+    private OrderCancelType cancelType;
 
     @OneToMany(
             fetch = FetchType.LAZY,

--- a/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/persistence/jpa/OrderMapper.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/persistence/jpa/OrderMapper.java
@@ -30,6 +30,7 @@ public class OrderMapper {
                 order.getRequestMemo(),
                 order.getStatus(),
                 order.getPreviousStatus(),
+                order.getCancelType(),
                 order.getOrderItems().stream()
                         .map(this::toItemEntity)
                         .toList(),
@@ -62,6 +63,7 @@ public class OrderMapper {
                 entity.getRequestMemo(),
                 entity.getStatus(),
                 entity.getPreviousStatus(),
+                entity.getCancelType(),
                 entity.getCreatedAt(),
                 items,
                 entity.getVersion()

--- a/order-service/src/main/java/com/firstlogistics/orderservice/presentation/OrderController.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/presentation/OrderController.java
@@ -69,4 +69,15 @@ public class OrderController {
                         OrderStatusResponse.of(orderId, status)));
     }
 
+    @PatchMapping("/{orderId}/cancellation-request")
+    public ResponseEntity<ApiResponse<OrderStatusResponse>> requestCancel(
+            @RequestHeader("X-User-Id") UUID userId,
+            @PathVariable UUID orderId
+    ) {
+        String status = orderCommandService.requestCancel(userId, orderId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(OrderSuccessCode.ORDER_STATUS_UPDATED,
+                        OrderStatusResponse.of(orderId, status)));
+    }
+
 }

--- a/order-service/src/main/java/com/firstlogistics/orderservice/presentation/OrderController.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/presentation/OrderController.java
@@ -58,4 +58,15 @@ public class OrderController {
                         OrderStatusResponse.of(orderId, status)));
     }
 
+    @PatchMapping("/{orderId}/calcellation")
+    public ResponseEntity<ApiResponse<OrderStatusResponse>> cancelOrder(
+            @RequestHeader("X-User-Id") UUID userId,
+            @PathVariable UUID orderId
+    ) {
+        String status = orderCommandService.cancelOrder(userId, orderId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(OrderSuccessCode.ORDER_STATUS_UPDATED,
+                        OrderStatusResponse.of(orderId, status)));
+    }
+
 }

--- a/order-service/src/main/java/com/firstlogistics/orderservice/presentation/OrderController.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/presentation/OrderController.java
@@ -58,7 +58,7 @@ public class OrderController {
                         OrderStatusResponse.of(orderId, status)));
     }
 
-    @PatchMapping("/{orderId}/calcellation")
+    @PatchMapping("/{orderId}/cancellation")
     public ResponseEntity<ApiResponse<OrderStatusResponse>> cancelOrder(
             @RequestHeader("X-User-Id") UUID userId,
             @PathVariable UUID orderId

--- a/order-service/src/main/java/com/firstlogistics/orderservice/presentation/OrderController.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/presentation/OrderController.java
@@ -80,4 +80,15 @@ public class OrderController {
                         OrderStatusResponse.of(orderId, status)));
     }
 
+    @PatchMapping("/{orderId}/cancellation-request/approval")
+    public ResponseEntity<ApiResponse<OrderStatusResponse>> approveCancelRequest(
+            @RequestHeader("X-User-Id") UUID userId,
+            @PathVariable UUID orderId
+    ) {
+        String status = orderCommandService.approveCancelRequest(userId, orderId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(OrderSuccessCode.ORDER_STATUS_UPDATED,
+                        OrderStatusResponse.of(orderId, status)));
+    }
+
 }

--- a/order-service/src/main/java/com/firstlogistics/orderservice/presentation/OrderController.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/presentation/OrderController.java
@@ -91,4 +91,15 @@ public class OrderController {
                         OrderStatusResponse.of(orderId, status)));
     }
 
+    @PatchMapping("/{orderId}/cancellation-request/rejection")
+    public ResponseEntity<ApiResponse<OrderStatusResponse>> rejectCancelRequest(
+            @RequestHeader("X-User-Id") UUID userId,
+            @PathVariable UUID orderId
+    ) {
+        String status = orderCommandService.rejectCancelRequest(userId, orderId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(OrderSuccessCode.ORDER_STATUS_UPDATED,
+                        OrderStatusResponse.of(orderId, status)));
+    }
+
 }

--- a/order-service/src/test/java/com/firstlogistics/orderservice/application/OrderCommandServiceTest.java
+++ b/order-service/src/test/java/com/firstlogistics/orderservice/application/OrderCommandServiceTest.java
@@ -205,4 +205,113 @@ class OrderCommandServiceTest {
         verify(orderRepository, never()).save(any(Order.class));
         verify(eventPublisher, never()).publishEvent(any());
     }
+
+    // --- 주문 취소 및 취소 요청 테스트 ---
+
+    @Test
+    @DisplayName("성공: 관리자가 직접 주문을 취소하면 CANCELLED 상태가 되고 ADMIN_CANCEL 사유가 저장된다")
+    void cancelOrder_Success() {
+        // given
+        UUID orderId = UUID.randomUUID();
+        Order order = OrderTestBuilder.builder()
+                .id(orderId)
+                .status(OrderStatus.RESERVED)
+                .build();
+
+        when(orderRepository.findById(OrderId.of(orderId))).thenReturn(Optional.of(order));
+
+        // when
+        String resultStatus = orderCommandService.cancelOrder(USER_ID, orderId);
+
+        // then
+        assertThat(resultStatus).isEqualTo("CANCELLED");
+        assertThat(order.getCancelType()).isEqualTo(com.firstlogistics.orderservice.domain.enums.OrderCancelType.ADMIN_CANCEL);
+        verify(orderRepository).save(order);
+        verify(eventPublisher).publishEvent(any(OrderCancelledEvent.class));
+    }
+
+    @Test
+    @DisplayName("성공: 발주처가 취소 요청 시 CANCEL_REQUESTED 상태가 된다")
+    void requestCancel_Success() {
+        // given
+        UUID orderId = UUID.randomUUID();
+        Order order = OrderTestBuilder.builder()
+                .id(orderId)
+                .status(OrderStatus.RESERVED)
+                .build();
+
+        when(orderRepository.findById(OrderId.of(orderId))).thenReturn(Optional.of(order));
+
+        // when
+        String resultStatus = orderCommandService.requestCancel(USER_ID, orderId);
+
+        // then
+        assertThat(resultStatus).isEqualTo("CANCEL_REQUESTED");
+        verify(orderRepository).save(order);
+    }
+
+    @Test
+    @DisplayName("성공: 취소 요청을 승인하면 CANCELLED 상태가 되고 ORDERER_REQUEST 사유가 저장된다")
+    void approveCancelRequest_Success() {
+        // given
+        UUID orderId = UUID.randomUUID();
+        // 취소 요청 상태의 주문 준비
+        Order order = OrderTestBuilder.builder()
+                .id(orderId)
+                .status(OrderStatus.CANCEL_REQUESTED)
+                .previousStatus(OrderStatus.RESERVED)
+                .build();
+
+        when(orderRepository.findById(OrderId.of(orderId))).thenReturn(Optional.of(order));
+
+        // when
+        String resultStatus = orderCommandService.approveCancelRequest(USER_ID, orderId);
+
+        // then
+        assertThat(resultStatus).isEqualTo("CANCELLED");
+        assertThat(order.getCancelType()).isEqualTo(com.firstlogistics.orderservice.domain.enums.OrderCancelType.ORDERER_REQUEST);
+        verify(orderRepository).save(order);
+        verify(eventPublisher).publishEvent(any(OrderCancelledEvent.class));
+    }
+
+    @Test
+    @DisplayName("성공: 취소 요청을 반려하면 이전 상태로 복구되고 사유는 null이다")
+    void rejectCancelRequest_Success() {
+        // given
+        UUID orderId = UUID.randomUUID();
+        Order order = OrderTestBuilder.builder()
+                .id(orderId)
+                .status(OrderStatus.CANCEL_REQUESTED)
+                .previousStatus(OrderStatus.RESERVED)
+                .build();
+
+        when(orderRepository.findById(OrderId.of(orderId))).thenReturn(Optional.of(order));
+
+        // when
+        String resultStatus = orderCommandService.rejectCancelRequest(USER_ID, orderId);
+
+        // then
+        assertThat(resultStatus).isEqualTo("RESERVED");
+        assertThat(order.getCancelType()).isNull();
+        assertThat(order.getPreviousStatus()).isNull();
+        verify(orderRepository).save(order);
+    }
+
+    @Test
+    @DisplayName("실패: 취소 요청 상태가 아닌 주문을 반려하려 하면 예외가 발생한다")
+    void rejectCancelRequest_Fail_InvalidStatus() {
+        // given
+        UUID orderId = UUID.randomUUID();
+        Order order = OrderTestBuilder.builder()
+                .id(orderId)
+                .status(OrderStatus.ACCEPTED)
+                .build();
+
+        when(orderRepository.findById(OrderId.of(orderId))).thenReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() -> orderCommandService.rejectCancelRequest(USER_ID, orderId))
+                .isInstanceOf(OrderException.class)
+                .hasMessage(OrderErrorCode.CANNOT_REJECT_CANCEL.getMessage());
+    }
 }

--- a/order-service/src/test/java/com/firstlogistics/orderservice/application/OrderCommandServiceTest.java
+++ b/order-service/src/test/java/com/firstlogistics/orderservice/application/OrderCommandServiceTest.java
@@ -3,6 +3,7 @@ package com.firstlogistics.orderservice.application;
 import com.firstlogistics.orderservice.application.dto.CreateOrderCommand;
 import com.firstlogistics.orderservice.domain.entity.Order;
 import com.firstlogistics.orderservice.domain.entity.OrderTestBuilder;
+import com.firstlogistics.orderservice.domain.enums.OrderCancelType;
 import com.firstlogistics.orderservice.domain.enums.OrderStatus;
 import com.firstlogistics.orderservice.domain.event.OrderAcceptedEvent;
 import com.firstlogistics.orderservice.domain.event.OrderCancelledEvent;
@@ -225,7 +226,7 @@ class OrderCommandServiceTest {
 
         // then
         assertThat(resultStatus).isEqualTo("CANCELLED");
-        assertThat(order.getCancelType()).isEqualTo(com.firstlogistics.orderservice.domain.enums.OrderCancelType.ADMIN_CANCEL);
+        assertThat(order.getCancelType()).isEqualTo(OrderCancelType.ADMIN_CANCEL);
         verify(orderRepository).save(order);
         verify(eventPublisher).publishEvent(any(OrderCancelledEvent.class));
     }
@@ -269,13 +270,13 @@ class OrderCommandServiceTest {
 
         // then
         assertThat(resultStatus).isEqualTo("CANCELLED");
-        assertThat(order.getCancelType()).isEqualTo(com.firstlogistics.orderservice.domain.enums.OrderCancelType.ORDERER_REQUEST);
+        assertThat(order.getCancelType()).isEqualTo(OrderCancelType.ORDERER_REQUEST);
         verify(orderRepository).save(order);
         verify(eventPublisher).publishEvent(any(OrderCancelledEvent.class));
     }
 
     @Test
-    @DisplayName("성공: 취소 요청을 반려하면 이전 상태로 복구되고 사유는 null이다")
+    @DisplayName("성공: 취소 요청을 반려하면 이전 상태로 복구된다")
     void rejectCancelRequest_Success() {
         // given
         UUID orderId = UUID.randomUUID();
@@ -292,7 +293,6 @@ class OrderCommandServiceTest {
 
         // then
         assertThat(resultStatus).isEqualTo("RESERVED");
-        assertThat(order.getCancelType()).isNull();
         assertThat(order.getPreviousStatus()).isNull();
         verify(orderRepository).save(order);
     }

--- a/order-service/src/test/java/com/firstlogistics/orderservice/domain/entity/OrderTestBuilder.java
+++ b/order-service/src/test/java/com/firstlogistics/orderservice/domain/entity/OrderTestBuilder.java
@@ -1,5 +1,6 @@
 package com.firstlogistics.orderservice.domain.entity;
 
+import com.firstlogistics.orderservice.domain.enums.OrderCancelType;
 import com.firstlogistics.orderservice.domain.enums.OrderStatus;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -20,6 +21,7 @@ public class OrderTestBuilder {
     private String requestMemo = "빠른 배송 바랍니다.";
     private OrderStatus status = OrderStatus.PENDING;
     private OrderStatus previousStatus = null;
+    private OrderCancelType cancelType = null;
     private LocalDateTime orderedAt = LocalDateTime.now();
     private List<OrderItem> orderItems = new ArrayList<>();
     private Long version = 0L;
@@ -52,7 +54,7 @@ public class OrderTestBuilder {
         return Order.reconstitute(
                 id, supplierCompanyId, supplierManagerId, receiverCompanyId, receiverManagerId,
                 deliveryId, roadAddress, detailAddress, totalAmount, dueDate,
-                requestMemo, status, previousStatus, orderedAt, orderItems, version
+                requestMemo, status, previousStatus, cancelType, orderedAt, orderItems, version
         );
     }
 }

--- a/order-service/src/test/java/com/firstlogistics/orderservice/infrastructure/persistence/jpa/OrderMapperTest.java
+++ b/order-service/src/test/java/com/firstlogistics/orderservice/infrastructure/persistence/jpa/OrderMapperTest.java
@@ -56,6 +56,7 @@ class OrderMapperTest {
                 "배송 메시지",
                 OrderStatus.PENDING,
                 null,
+                null,
                 new ArrayList<>(),
                 null
         );


### PR DESCRIPTION
### 📌 관련 이슈
- close #119 

### 💡 작업 내용
- Order에 cancelType 필드 추가
- 주문 취소 API
- 주문 취소 요청 API
- 주문 취소 요청 승인 API
- 주문 취소 요청 거절 API

### 🔍 변경 이유
- 

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 취소 유형 분류 추가(발주처 요청, 재고 부족, 공급처 취소, 관리자 취소, 시스템 오류, 기타)
  * 주문 취소 워크플로우 확장: 즉시 취소, 취소 요청, 요청 승인·거절을 처리하는 API 추가
  * 취소 실행 흐름 개선으로 다양한 취소 시나리오 분리 처리

* **버그 수정 / 유효성**
  * 취소 시 취소 사유 필수 검증 및 관련 오류 코드 추가

* **테스트**
  * 주문 취소 라이프사이클 관련 단위 테스트 추가 및 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->