### PR TITLE
feat: 배송 상태 변경(배송 시작, 목적지 허브 도착, 목적지 허브 받기, 업체 배송 시작, 배송 완료)

### DIFF
--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/DeliveryCommandService.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/DeliveryCommandService.java
@@ -190,7 +190,7 @@ public class DeliveryCommandService {
 		return UpdateDeliveryResult.from(savedDelivery);
 	}
 
-	public ChangeDeliveryStatusResult startDelivery(ChangeDeliveryStatusCommand command) {
+	public ChangeDeliveryStatusResult startHubDelivery(ChangeDeliveryStatusCommand command) {
 		Delivery delivery = deliveryRepository.findById(DeliveryId.of(command.deliveryId()))
 			.orElseThrow(() -> new DeliveryException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
 
@@ -198,7 +198,24 @@ public class DeliveryCommandService {
 		deliveryPermissionValidator.validate(accessContext, command.role(), command.userId(),
 			Set.of(UserRole.MASTER, UserRole.HUB_MANAGER, UserRole.DELIVERY_MANAGER));
 
-		delivery.startNextPhase();
+		delivery.startHubDelivery();
+		Delivery savedDelivery = deliveryRepository.save(delivery);
+
+		deliveryEventPublisher.publishDeliveryStatusChanged(
+			DeliveryStatusChangedEvent.create(savedDelivery));
+
+		return ChangeDeliveryStatusResult.from(savedDelivery);
+	}
+
+	public ChangeDeliveryStatusResult startCompanyDelivery(ChangeDeliveryStatusCommand command) {
+		Delivery delivery = deliveryRepository.findById(DeliveryId.of(command.deliveryId()))
+			.orElseThrow(() -> new DeliveryException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
+
+		DeliveryAccessContext accessContext = DeliveryAccessContext.from(delivery);
+		deliveryPermissionValidator.validate(accessContext, command.role(), command.userId(),
+			Set.of(UserRole.MASTER, UserRole.HUB_MANAGER, UserRole.DELIVERY_MANAGER));
+
+		delivery.startCompanyDelivery();
 		Delivery savedDelivery = deliveryRepository.save(delivery);
 
 		deliveryEventPublisher.publishDeliveryStatusChanged(

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/DeliveryCommandService.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/DeliveryCommandService.java
@@ -1,7 +1,9 @@
 package com.firstlogistics.deliverservice.application;
 
+import com.firstlogistics.deliverservice.application.dto.command.ChangeDeliveryStatusCommand;
 import com.firstlogistics.deliverservice.application.dto.command.CreateDeliveryCommand;
 import com.firstlogistics.deliverservice.application.dto.command.UpdateDeliveryCommand;
+import com.firstlogistics.deliverservice.application.dto.result.ChangeDeliveryStatusResult;
 import com.firstlogistics.deliverservice.application.dto.result.CreateDeliveryResult;
 import com.firstlogistics.deliverservice.application.dto.result.UpdateDeliveryResult;
 import com.firstlogistics.deliverservice.application.permission.DeliveryAccessContext;
@@ -12,6 +14,7 @@ import com.firstlogistics.deliverservice.domain.entity.DeliveryRoute;
 import com.firstlogistics.deliverservice.domain.entity.DeliveryManager;
 import com.firstlogistics.deliverservice.domain.enums.UserRole;
 import com.firstlogistics.deliverservice.domain.event.DeliveryCreatedEvent;
+import com.firstlogistics.deliverservice.domain.event.DeliveryStatusChangedEvent;
 import com.firstlogistics.deliverservice.domain.event.DeliveryUpdatedEvent;
 import com.firstlogistics.deliverservice.domain.exception.DeliveryCreationException;
 import com.firstlogistics.deliverservice.domain.exception.DeliveryErrorCode;
@@ -185,6 +188,74 @@ public class DeliveryCommandService {
 		deliveryEventPublisher.publishDeliveryUpdated(deliveryUpdatedEvent);
 
 		return UpdateDeliveryResult.from(savedDelivery);
+	}
+
+	public ChangeDeliveryStatusResult startDelivery(ChangeDeliveryStatusCommand command) {
+		Delivery delivery = deliveryRepository.findById(DeliveryId.of(command.deliveryId()))
+			.orElseThrow(() -> new DeliveryException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
+
+		DeliveryAccessContext accessContext = DeliveryAccessContext.from(delivery);
+		deliveryPermissionValidator.validate(accessContext, command.role(), command.userId(),
+			Set.of(UserRole.MASTER, UserRole.HUB_MANAGER, UserRole.DELIVERY_MANAGER));
+
+		delivery.startNextPhase();
+		Delivery savedDelivery = deliveryRepository.save(delivery);
+
+		deliveryEventPublisher.publishDeliveryStatusChanged(
+			DeliveryStatusChangedEvent.create(savedDelivery));
+
+		return ChangeDeliveryStatusResult.from(savedDelivery);
+	}
+
+	public ChangeDeliveryStatusResult arriveHub(ChangeDeliveryStatusCommand command) {
+		Delivery delivery = deliveryRepository.findById(DeliveryId.of(command.deliveryId()))
+			.orElseThrow(() -> new DeliveryException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
+
+		DeliveryAccessContext accessContext = DeliveryAccessContext.from(delivery);
+		deliveryPermissionValidator.validate(accessContext, command.role(), command.userId(),
+			Set.of(UserRole.MASTER, UserRole.DELIVERY_MANAGER));
+
+		delivery.arriveAtHub();
+		Delivery savedDelivery = deliveryRepository.save(delivery);
+
+		deliveryEventPublisher.publishDeliveryStatusChanged(
+			DeliveryStatusChangedEvent.create(savedDelivery));
+
+		return ChangeDeliveryStatusResult.from(savedDelivery);
+	}
+
+	public ChangeDeliveryStatusResult receiveAtHub(ChangeDeliveryStatusCommand command) {
+		Delivery delivery = deliveryRepository.findById(DeliveryId.of(command.deliveryId()))
+			.orElseThrow(() -> new DeliveryException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
+
+		DeliveryAccessContext accessContext = DeliveryAccessContext.from(delivery);
+		deliveryPermissionValidator.validate(accessContext, command.role(), command.userId(),
+			Set.of(UserRole.MASTER, UserRole.HUB_MANAGER));
+
+		delivery.receiveAtHub();
+		Delivery savedDelivery = deliveryRepository.save(delivery);
+
+		deliveryEventPublisher.publishDeliveryStatusChanged(
+			DeliveryStatusChangedEvent.create(savedDelivery));
+
+		return ChangeDeliveryStatusResult.from(savedDelivery);
+	}
+
+	public ChangeDeliveryStatusResult completeDelivery(ChangeDeliveryStatusCommand command) {
+		Delivery delivery = deliveryRepository.findById(DeliveryId.of(command.deliveryId()))
+			.orElseThrow(() -> new DeliveryException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
+
+		DeliveryAccessContext accessContext = DeliveryAccessContext.from(delivery);
+		deliveryPermissionValidator.validate(accessContext, command.role(), command.userId(),
+			Set.of(UserRole.MASTER, UserRole.DELIVERY_MANAGER));
+
+		delivery.completeDelivery();
+		Delivery savedDelivery = deliveryRepository.save(delivery);
+
+		deliveryEventPublisher.publishDeliveryStatusChanged(
+			DeliveryStatusChangedEvent.create(savedDelivery));
+
+		return ChangeDeliveryStatusResult.from(savedDelivery);
 	}
 
 	private DeliveryCreatedEvent buildDeliveryCreatedEvent(

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/DeliveryQueryService.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/DeliveryQueryService.java
@@ -60,7 +60,7 @@ public class DeliveryQueryService {
 						: null;
 		UUID companyId =
 				userRole == UserRole.COMPANY_MANAGER
-						? companyPort.getCompanyByManagerId(query.userId()).companyId()
+						? companyPort.getCompanyByUserId(query.userId()).companyId()
 						: null;
 		UUID deliveryManagerId =
 				userRole == UserRole.DELIVERY_MANAGER

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/dto/command/ChangeDeliveryStatusCommand.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/dto/command/ChangeDeliveryStatusCommand.java
@@ -1,0 +1,22 @@
+package com.firstlogistics.deliverservice.application.dto.command;
+
+import com.firstlogistics.deliverservice.domain.exception.DeliveryErrorCode;
+import com.firstlogistics.deliverservice.domain.exception.DeliveryException;
+
+import java.util.UUID;
+
+public record ChangeDeliveryStatusCommand(
+	UUID deliveryId,
+	String role,
+	UUID userId
+) {
+	public ChangeDeliveryStatusCommand {
+		if (deliveryId == null || role == null || userId == null) {
+			throw new DeliveryException(DeliveryErrorCode.INVALID_COMMAND_PARAMS);
+		}
+	}
+
+	public static ChangeDeliveryStatusCommand of(UUID deliveryId, String role, UUID userId) {
+		return new ChangeDeliveryStatusCommand(deliveryId, role, userId);
+	}
+}

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/dto/result/ChangeDeliveryStatusResult.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/dto/result/ChangeDeliveryStatusResult.java
@@ -1,0 +1,13 @@
+package com.firstlogistics.deliverservice.application.dto.result;
+
+import com.firstlogistics.deliverservice.domain.entity.Delivery;
+
+import java.util.UUID;
+
+public record ChangeDeliveryStatusResult(
+	UUID deliveryId
+) {
+	public static ChangeDeliveryStatusResult from(Delivery delivery) {
+		return new ChangeDeliveryStatusResult(delivery.getId().id());
+	}
+}

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/facade/DeliveryCommandFacade.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/facade/DeliveryCommandFacade.java
@@ -32,7 +32,7 @@ public class DeliveryCommandFacade {
         UUID sourceHubId = supplierCompany.hubId();
         UUID destinationHubId = receiverCompany.hubId();
 
-        HubRouteResponse hubRoute = hubPort.getHubRoute(sourceHubId, destinationHubId);
+        HubRouteResponse hubRoute = hubPort.getHubRoute(sourceHubId, destinationHubId, command.receiverCompanyId());
 
         List<String> lockKeys = generateLockKeys(hubRoute);
 

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/permission/strategy/CompanyManagerPermissionStrategy.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/permission/strategy/CompanyManagerPermissionStrategy.java
@@ -24,7 +24,7 @@ public class CompanyManagerPermissionStrategy implements RolePermissionStrategy 
 
 	@Override
 	public void validate(DeliveryAccessContext context, UUID userId) {
-		UUID companyId = companyPort.getCompanyByManagerId(userId).companyId();
+		UUID companyId = companyPort.getCompanyByUserId(userId).companyId();
 		if (!companyId.equals(context.receiverCompanyId())) {
 			throw new DeliveryException(DeliveryErrorCode.DELIVERY_ACCESS_DENIED);
 		}

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/port/CompanyPort.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/port/CompanyPort.java
@@ -8,5 +8,5 @@ public interface CompanyPort {
 
 	CompanyResponse getCompany(UUID companyId);
 
-	CompanyResponse getCompanyByManagerId(UUID managerId);
+	CompanyResponse getCompanyByUserId(UUID userId);
 }

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/port/HubManagerPort.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/port/HubManagerPort.java
@@ -6,5 +6,5 @@ import java.util.UUID;
 
 public interface HubManagerPort {
 
-	HubManagerResponse getHubManager(UUID managerId);
+	HubManagerResponse getHubManager(UUID userId);
 }

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/port/HubPort.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/port/HubPort.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 
 public interface HubPort {
 
-	HubRouteResponse getHubRoute(UUID sourceHubId, UUID destinationHubId);
+	HubRouteResponse getHubRoute(UUID sourceHubId, UUID destinationHubId, UUID receiverCompanyId);
 
 	List<HubResponse> getHubs(List<UUID> hubIds);
 }

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/publisher/DeliveryEventPublisher.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/publisher/DeliveryEventPublisher.java
@@ -1,6 +1,7 @@
 package com.firstlogistics.deliverservice.application.publisher;
 
 import com.firstlogistics.deliverservice.domain.event.DeliveryCreatedEvent;
+import com.firstlogistics.deliverservice.domain.event.DeliveryStatusChangedEvent;
 import com.firstlogistics.deliverservice.domain.event.DeliveryUpdatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,5 +23,10 @@ public class DeliveryEventPublisher {
 	public void publishDeliveryUpdated(DeliveryUpdatedEvent event) {
 		applicationEventPublisher.publishEvent(event);
 		log.debug("DeliveryUpdatedEvent 등록 - deliveryId: {}", event.deliveryId());
+	}
+
+	public void publishDeliveryStatusChanged(DeliveryStatusChangedEvent event) {
+		applicationEventPublisher.publishEvent(event);
+		log.debug("DeliveryStatusChangedEvent 등록 - deliveryId: {}, status: {}", event.deliveryId(), event.status());
 	}
 }

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/entity/Delivery.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/entity/Delivery.java
@@ -136,9 +136,10 @@ public class Delivery {
 
 	public void completeDelivery() {
 		validateStatusTransition(Set.of(DeliveryStatus.FOR_COMPANY_MOVING));
-		this.routes.stream()
+		DeliveryRoute lastRoute = this.routes.stream()
 			.max(Comparator.comparingInt(DeliveryRoute::getDeliveryRouteSequence))
-			.ifPresent(DeliveryRoute::completeRoute);
+			.orElseThrow(() -> new DeliveryException(DeliveryErrorCode.NEXT_ROUTE_NOT_FOUND));
+		lastRoute.completeRoute();
 		this.status = DeliveryStatus.COMPLETED;
 	}
 

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/entity/Delivery.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/entity/Delivery.java
@@ -1,6 +1,7 @@
 package com.firstlogistics.deliverservice.domain.entity;
 
 import com.firstlogistics.deliverservice.domain.enums.DeliveryStatus;
+import com.firstlogistics.deliverservice.domain.enums.RouteStatus;
 import com.firstlogistics.deliverservice.domain.exception.DeliveryErrorCode;
 import com.firstlogistics.deliverservice.domain.exception.DeliveryException;
 import com.firstlogistics.deliverservice.domain.vo.Address;
@@ -13,7 +14,9 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 @Getter
@@ -88,23 +91,54 @@ public class Delivery {
 		);
 	}
 
-	public void moveToNextHub() {
-		this.status = DeliveryStatus.HUB_MOVING;
+	public void startNextPhase() {
+		validateStatusTransition(Set.of(DeliveryStatus.CREATED, DeliveryStatus.HUB_WAITING));
+		if (this.currentHubId.equals(this.destinationHubId)) {
+			startLastMile();
+		} else {
+			moveToNextHub();
+		}
 	}
 
-	public void arriveAtHub() {
-		this.status = DeliveryStatus.HUB_WAITING;
+	private void moveToNextHub() {
+		DeliveryRoute nextRoute = this.routes.stream()
+			.filter(route -> route.getStatus() == RouteStatus.CREATED)
+			.min(Comparator.comparingInt(DeliveryRoute::getDeliveryRouteSequence))
+			.orElseThrow(() -> new DeliveryException(DeliveryErrorCode.ROUTE_NOT_FOUND));
+		nextRoute.startRoute();
+		this.status = DeliveryStatus.FOR_HUB_MOVING;
 	}
 
-	public void arriveAtDestination() {
-		this.status = DeliveryStatus.DESTINATION_ARRIVED;
-	}
-
-	public void startLastMile() {
+	private void startLastMile() {
+		DeliveryRoute companyRoute = this.routes.stream()
+			.filter(route -> route.getStatus() == RouteStatus.CREATED)
+			.min(Comparator.comparingInt(DeliveryRoute::getDeliveryRouteSequence))
+			.orElseThrow(() -> new DeliveryException(DeliveryErrorCode.ROUTE_NOT_FOUND));
+		companyRoute.startRoute();
 		this.status = DeliveryStatus.FOR_COMPANY_MOVING;
 	}
 
+	public void arriveAtHub() {
+		validateStatusTransition(Set.of(DeliveryStatus.FOR_HUB_MOVING));
+		DeliveryRoute currentRoute = this.routes.stream()
+			.filter(route -> route.getStatus() == RouteStatus.MOVING)
+			.findFirst()
+			.orElseThrow(() -> new DeliveryException(DeliveryErrorCode.ROUTE_NOT_FOUND));
+		currentRoute.arriveAtDestination();
+		this.currentHubId = currentRoute.getDestinationHubId();
+		this.status = DeliveryStatus.HUB_ARRIVED;
+	}
+
+	public void receiveAtHub() {
+		validateStatusTransition(Set.of(DeliveryStatus.HUB_ARRIVED));
+		this.status = DeliveryStatus.HUB_WAITING;
+	}
+
 	public void completeDelivery() {
+		validateStatusTransition(Set.of(DeliveryStatus.FOR_COMPANY_MOVING));
+		this.routes.stream()
+			.max(Comparator.comparingInt(DeliveryRoute::getDeliveryRouteSequence))
+			.ifPresent(DeliveryRoute::completeRoute);
 		this.status = DeliveryStatus.COMPLETED;
 	}
 
@@ -130,6 +164,12 @@ public class Delivery {
 	private void validateBeforeDelivery() {
 		if (this.status != DeliveryStatus.CREATED) {
 			throw new DeliveryException(DeliveryErrorCode.DELIVERY_NOT_MODIFIABLE);
+		}
+	}
+
+	private void validateStatusTransition(Set<DeliveryStatus> allowedStatuses) {
+		if (!allowedStatuses.contains(this.status)) {
+			throw new DeliveryException(DeliveryErrorCode.INVALID_STATUS_TRANSITION);
 		}
 	}
 }

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/entity/Delivery.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/entity/Delivery.java
@@ -91,31 +91,31 @@ public class Delivery {
 		);
 	}
 
-	public void startNextPhase() {
+	public void startHubDelivery() {
 		validateStatusTransition(Set.of(DeliveryStatus.CREATED, DeliveryStatus.HUB_WAITING));
 		if (this.currentHubId.equals(this.destinationHubId)) {
-			startLastMile();
-		} else {
-			moveToNextHub();
+			throw new DeliveryException(DeliveryErrorCode.INVALID_STATUS_TRANSITION);
 		}
-	}
-
-	private void moveToNextHub() {
-		DeliveryRoute nextRoute = this.routes.stream()
-			.filter(route -> route.getStatus() == RouteStatus.CREATED)
-			.min(Comparator.comparingInt(DeliveryRoute::getDeliveryRouteSequence))
-			.orElseThrow(() -> new DeliveryException(DeliveryErrorCode.ROUTE_NOT_FOUND));
+		DeliveryRoute nextRoute = findNextCreatedRoute();
 		nextRoute.startRoute();
 		this.status = DeliveryStatus.FOR_HUB_MOVING;
 	}
 
-	private void startLastMile() {
-		DeliveryRoute companyRoute = this.routes.stream()
+	public void startCompanyDelivery() {
+		validateStatusTransition(Set.of(DeliveryStatus.HUB_WAITING));
+		if (!this.currentHubId.equals(this.destinationHubId)) {
+			throw new DeliveryException(DeliveryErrorCode.INVALID_STATUS_TRANSITION);
+		}
+		DeliveryRoute companyRoute = findNextCreatedRoute();
+		companyRoute.startRoute();
+		this.status = DeliveryStatus.FOR_COMPANY_MOVING;
+	}
+
+	private DeliveryRoute findNextCreatedRoute() {
+		return this.routes.stream()
 			.filter(route -> route.getStatus() == RouteStatus.CREATED)
 			.min(Comparator.comparingInt(DeliveryRoute::getDeliveryRouteSequence))
 			.orElseThrow(() -> new DeliveryException(DeliveryErrorCode.ROUTE_NOT_FOUND));
-		companyRoute.startRoute();
-		this.status = DeliveryStatus.FOR_COMPANY_MOVING;
 	}
 
 	public void arriveAtHub() {

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/entity/Delivery.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/entity/Delivery.java
@@ -94,7 +94,7 @@ public class Delivery {
 	public void startHubDelivery() {
 		validateStatusTransition(Set.of(DeliveryStatus.CREATED, DeliveryStatus.HUB_WAITING));
 		if (this.currentHubId.equals(this.destinationHubId)) {
-			throw new DeliveryException(DeliveryErrorCode.INVALID_STATUS_TRANSITION);
+			throw new DeliveryException(DeliveryErrorCode.NOT_HUB_DELIVERY_PHASE);
 		}
 		DeliveryRoute nextRoute = findNextCreatedRoute();
 		nextRoute.startRoute();
@@ -104,7 +104,7 @@ public class Delivery {
 	public void startCompanyDelivery() {
 		validateStatusTransition(Set.of(DeliveryStatus.HUB_WAITING));
 		if (!this.currentHubId.equals(this.destinationHubId)) {
-			throw new DeliveryException(DeliveryErrorCode.INVALID_STATUS_TRANSITION);
+			throw new DeliveryException(DeliveryErrorCode.NOT_COMPANY_DELIVERY_PHASE);
 		}
 		DeliveryRoute companyRoute = findNextCreatedRoute();
 		companyRoute.startRoute();
@@ -115,7 +115,7 @@ public class Delivery {
 		return this.routes.stream()
 			.filter(route -> route.getStatus() == RouteStatus.CREATED)
 			.min(Comparator.comparingInt(DeliveryRoute::getDeliveryRouteSequence))
-			.orElseThrow(() -> new DeliveryException(DeliveryErrorCode.ROUTE_NOT_FOUND));
+			.orElseThrow(() -> new DeliveryException(DeliveryErrorCode.NEXT_ROUTE_NOT_FOUND));
 	}
 
 	public void arriveAtHub() {
@@ -123,7 +123,7 @@ public class Delivery {
 		DeliveryRoute currentRoute = this.routes.stream()
 			.filter(route -> route.getStatus() == RouteStatus.MOVING)
 			.findFirst()
-			.orElseThrow(() -> new DeliveryException(DeliveryErrorCode.ROUTE_NOT_FOUND));
+			.orElseThrow(() -> new DeliveryException(DeliveryErrorCode.MOVING_ROUTE_NOT_FOUND));
 		currentRoute.arriveAtDestination();
 		this.currentHubId = currentRoute.getDestinationHubId();
 		this.status = DeliveryStatus.HUB_ARRIVED;

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/entity/DeliveryRoute.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/entity/DeliveryRoute.java
@@ -76,12 +76,22 @@ public class DeliveryRoute {
 		);
 	}
 
-	public void departRoute() {
-		this.status = RouteStatus.HUB_MOVING;
+	public void startRoute() {
+		if (this.status != RouteStatus.CREATED) {
+			throw new DeliveryException(DeliveryErrorCode.ROUTE_ALREADY_STARTED);
+		}
+		this.status = RouteStatus.MOVING;
 	}
 
-	public void waitAtHub() {
-		this.status = RouteStatus.HUB_WAITING;
+	public void arriveAtDestination() {
+		if (this.status != RouteStatus.MOVING) {
+			throw new DeliveryException(DeliveryErrorCode.ROUTE_NOT_IN_TRANSIT);
+		}
+		this.status = RouteStatus.ARRIVED;
+	}
+
+	public void completeRoute() {
+		this.status = RouteStatus.COMPLETED;
 	}
 
 	public void assignManager(DeliveryManagerId managerId) {

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/entity/DeliveryRoute.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/entity/DeliveryRoute.java
@@ -91,6 +91,9 @@ public class DeliveryRoute {
 	}
 
 	public void completeRoute() {
+		if (this.status != RouteStatus.MOVING) {
+			throw new DeliveryException(DeliveryErrorCode.ROUTE_NOT_IN_TRANSIT);
+		}
 		this.status = RouteStatus.COMPLETED;
 	}
 

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/enums/DeliveryStatus.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/enums/DeliveryStatus.java
@@ -3,8 +3,8 @@ package com.firstlogistics.deliverservice.domain.enums;
 public enum DeliveryStatus {
 	CREATED("배송 생성됨"),
 	HUB_WAITING("허브 대기중"),
-	HUB_MOVING("허브 이동중"),
-	DESTINATION_ARRIVED("목적지 도착"),
+	FOR_HUB_MOVING("허브로 이동중"),
+	HUB_ARRIVED("허브 도착"),
 	FOR_COMPANY_MOVING("업체로 이동중"),
 	COMPLETED("배송 완료"),
 	CANCELLED("배송 취소"),

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/enums/RouteStatus.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/enums/RouteStatus.java
@@ -1,10 +1,10 @@
 package com.firstlogistics.deliverservice.domain.enums;
 
 public enum RouteStatus {
-	CREATED("배송 생성됨"),
-	HUB_WAITING("허브 대기중"),
-	HUB_MOVING("허브 이동중"),
-	DESTINATION_ARRIVED("허브 목적지 도착");
+	CREATED("생성됨"),
+	MOVING("이동중"),
+	ARRIVED("도착"),
+	COMPLETED("완료");
 
 	private final String description;
 

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/event/DeliveryStatusChangedEvent.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/event/DeliveryStatusChangedEvent.java
@@ -1,0 +1,71 @@
+package com.firstlogistics.deliverservice.domain.event;
+
+import com.firstlogistics.deliverservice.domain.entity.Delivery;
+import com.firstlogistics.deliverservice.domain.entity.DeliveryRoute;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record DeliveryStatusChangedEvent(
+	UUID deliveryId,
+	UUID orderId,
+	String status,
+	UUID sourceHubId,
+	UUID destinationHubId,
+	String deliveryRoadAddress,
+	String deliveryDetailAddress,
+	UUID receiverId,
+	String receiverSlackId,
+	UUID receiverCompanyId,
+	UUID currentHubId,
+	List<RouteInfo> routes,
+	LocalDateTime changedAt
+) {
+
+	public record RouteInfo(
+		UUID routeId,
+		int sequence,
+		UUID sourceHubId,
+		UUID destinationHubId,
+		int estimatedDistanceMeters,
+		int estimatedDurationMinutes,
+		String status,
+		UUID deliveryManagerId
+	) {
+		public static RouteInfo of(DeliveryRoute route) {
+			return new RouteInfo(
+				route.getId().id(),
+				route.getDeliveryRouteSequence(),
+				route.getSourceHubId(),
+				route.getDestinationHubId(),
+				route.getEstimatedDistance().meters(),
+				route.getEstimatedDuration().minutes(),
+				route.getStatus().name(),
+				route.getDeliveryManagerId() != null ? route.getDeliveryManagerId().id() : null
+			);
+		}
+	}
+
+	public static DeliveryStatusChangedEvent create(Delivery delivery) {
+		List<RouteInfo> routeInfos = delivery.getRoutes().stream()
+			.map(RouteInfo::of)
+			.toList();
+
+		return new DeliveryStatusChangedEvent(
+			delivery.getId().id(),
+			delivery.getOrderId(),
+			delivery.getStatus().name(),
+			delivery.getSourceHubId(),
+			delivery.getDestinationHubId(),
+			delivery.getDeliveryAddress().roadAddress(),
+			delivery.getDeliveryAddress().detailAddress(),
+			delivery.getReceiverId(),
+			delivery.getReceiverSlackId(),
+			delivery.getReceiverCompanyId(),
+			delivery.getCurrentHubId(),
+			routeInfos,
+			LocalDateTime.now()
+		);
+	}
+}

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/exception/DeliveryErrorCode.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/exception/DeliveryErrorCode.java
@@ -36,9 +36,12 @@ public enum DeliveryErrorCode implements ErrorCode {
 	DELIVERY_ACCESS_DENIED(HttpStatus.FORBIDDEN, "DR_E105", "해당 배송에 대한 접근 권한이 없습니다."),
 	DELIVERY_NOT_MODIFIABLE(HttpStatus.BAD_REQUEST, "DR_E106", "배송이 시작된 후에는 수정할 수 없습니다."),
 	INVALID_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "DR_E107", "현재 상태에서 해당 상태로 전환할 수 없습니다."),
-	ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "DR_E108", "진행 중인 배송 경로를 찾을 수 없습니다."),
+	NEXT_ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "DR_E108", "다음 배송 경로를 찾을 수 없습니다."),
 	ROUTE_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "DR_E109", "이미 출발한 경로입니다."),
 	ROUTE_NOT_IN_TRANSIT(HttpStatus.BAD_REQUEST, "DR_E110", "이동 중인 경로가 아닙니다."),
+	NOT_HUB_DELIVERY_PHASE(HttpStatus.BAD_REQUEST, "DR_E111", "마지막 허브에서는 허브 배송을 시작할 수 없습니다."),
+	NOT_COMPANY_DELIVERY_PHASE(HttpStatus.BAD_REQUEST, "DR_E112", "마지막 허브에 도착해야 업체 배송을 시작할 수 있습니다."),
+	MOVING_ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "DR_E113", "이동 중인 배송 경로를 찾을 수 없습니다."),
 
 	// 배송 담당자
 	HUB_DELIVERY_MANAGER_NOT_AVAILABLE(HttpStatus.NOT_FOUND, "DR_E201", "배정 가능한 허브 배송담당자가 없습니다."),

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/exception/DeliveryErrorCode.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/exception/DeliveryErrorCode.java
@@ -35,6 +35,10 @@ public enum DeliveryErrorCode implements ErrorCode {
 	INVALID_ROLE_SCOPE(HttpStatus.BAD_REQUEST, "DR_E104", "역할에 필요한 스코프 정보가 없습니다."),
 	DELIVERY_ACCESS_DENIED(HttpStatus.FORBIDDEN, "DR_E105", "해당 배송에 대한 접근 권한이 없습니다."),
 	DELIVERY_NOT_MODIFIABLE(HttpStatus.BAD_REQUEST, "DR_E106", "배송이 시작된 후에는 수정할 수 없습니다."),
+	INVALID_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "DR_E107", "현재 상태에서 해당 상태로 전환할 수 없습니다."),
+	ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "DR_E108", "진행 중인 배송 경로를 찾을 수 없습니다."),
+	ROUTE_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "DR_E109", "이미 출발한 경로입니다."),
+	ROUTE_NOT_IN_TRANSIT(HttpStatus.BAD_REQUEST, "DR_E110", "이동 중인 경로가 아닙니다."),
 
 	// 배송 담당자
 	HUB_DELIVERY_MANAGER_NOT_AVAILABLE(HttpStatus.NOT_FOUND, "DR_E201", "배정 가능한 허브 배송담당자가 없습니다."),

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/exception/DeliveryErrorCode.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/exception/DeliveryErrorCode.java
@@ -48,6 +48,9 @@ public enum DeliveryErrorCode implements ErrorCode {
 	COMPANY_DELIVERY_MANAGER_NOT_AVAILABLE(HttpStatus.NOT_FOUND, "DR_E202", "배정 가능한 업체 배송담당자가 없습니다."),
 	DELIVERY_MANAGER_NOT_FOUND(HttpStatus.NOT_FOUND, "DR_E203", "배송 담당자를 찾을 수 없습니다."),
 
+	HUB_MANAGER_NOT_FOUND(HttpStatus.NOT_FOUND, "DR_E204", "허브 관리자를 찾을 수 없습니다."),
+	COMPANY_MANAGER_NOT_FOUND(HttpStatus.NOT_FOUND, "DR_E205", "업체 담당자를 찾을 수 없습니다."),
+
 	// 외부 서비스
 	HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "DR_E401", "허브를 찾을 수 없습니다."),
 	COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "DR_E402", "업체를 찾을 수 없습니다."),

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/feign/CompanyClient.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/feign/CompanyClient.java
@@ -2,20 +2,21 @@ package com.firstlogistics.deliverservice.infrastructure.feign;
 
 import com.firstlogistics.deliverservice.application.port.dto.CompanyResponse;
 import com.firstlogistics.deliverservice.infrastructure.feign.config.FeignErrorDecoder;
-import com.firstlogistics.deliverservice.infrastructure.feign.dto.FeignResponse;
+import com.firstlogistics.deliverservice.infrastructure.feign.dto.FeignApiResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.List;
 import java.util.UUID;
 
 @FeignClient(name = "company-service", url = "${company-service.url:}", configuration = FeignErrorDecoder.class)
 public interface CompanyClient {
 
 	@GetMapping("/api/v1/companies/{companyId}")
-	FeignResponse<CompanyResponse> getCompany(@PathVariable("companyId") UUID companyId);
+	FeignApiResponse<CompanyResponse> getCompany(@PathVariable("companyId") UUID companyId);
 
 	@GetMapping("/api/v1/companies")
-	FeignResponse<CompanyResponse> getCompanyByManagerId(@RequestParam("managerId") UUID managerId);
+	FeignApiResponse<List<CompanyResponse>> getCompaniesByUserId(@RequestParam("userId") UUID userId);
 }

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/feign/HubClient.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/feign/HubClient.java
@@ -2,7 +2,7 @@ package com.firstlogistics.deliverservice.infrastructure.feign;
 
 import com.firstlogistics.deliverservice.application.port.dto.HubResponse;
 import com.firstlogistics.deliverservice.infrastructure.feign.config.FeignErrorDecoder;
-import com.firstlogistics.deliverservice.infrastructure.feign.dto.FeignResponse;
+import com.firstlogistics.deliverservice.infrastructure.feign.dto.FeignApiResponse;
 import com.firstlogistics.deliverservice.application.port.dto.HubRouteResponse;
 import com.firstlogistics.deliverservice.application.port.dto.HubManagerResponse;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -19,14 +19,14 @@ import java.util.UUID;
 public interface HubClient {
 
 	@GetMapping("/api/v1/hub-connections/routes")
-	FeignResponse<HubRouteResponse> getHubRoute(
+	FeignApiResponse<HubRouteResponse> getHubRoute(
 		@RequestParam("sourceHubId") UUID sourceHubId,
 		@RequestParam("destinationHubId") UUID destinationHubId
 	);
 
-	@GetMapping("/api/v1/hub-managers/{managerId}")
-	FeignResponse<HubManagerResponse> getHubManager(@PathVariable("managerId") UUID managerId);
+	@GetMapping("/api/v1/hub-managers")
+	FeignApiResponse<List<HubManagerResponse>> getHubManagersByUserId(@RequestParam("userId") UUID userId);
 
 	@PostMapping("/api/v1/hubs/ids")
-	FeignResponse<List<HubResponse>> getHubs(@RequestBody List<UUID> hubIds);
+	FeignApiResponse<List<HubResponse>> getHubs(@RequestBody List<UUID> hubIds);
 }

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/feign/HubClient.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/feign/HubClient.java
@@ -25,8 +25,8 @@ public interface HubClient {
 		@RequestParam("receiverCompanyId") UUID receiverCompanyId
 	);
 
-	@GetMapping("/api/v1/hub-managers")
-	FeignApiResponse<List<HubManagerResponse>> getHubManagersByUserId(@RequestParam("userId") UUID userId);
+	@GetMapping("/api/v1/hub-managers/users/{userId}")
+	FeignApiResponse<HubManagerResponse> getHubManagerByUserId(@PathVariable("userId") UUID userId);
 
 	@PostMapping("/api/v1/hubs/ids")
 	FeignApiResponse<List<HubResponse>> getHubs(@RequestBody List<UUID> hubIds);

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/feign/HubClient.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/feign/HubClient.java
@@ -21,7 +21,8 @@ public interface HubClient {
 	@GetMapping("/api/v1/hub-connections/routes")
 	FeignApiResponse<HubRouteResponse> getHubRoute(
 		@RequestParam("sourceHubId") UUID sourceHubId,
-		@RequestParam("destinationHubId") UUID destinationHubId
+		@RequestParam("destinationHubId") UUID destinationHubId,
+		@RequestParam("receiverCompanyId") UUID receiverCompanyId
 	);
 
 	@GetMapping("/api/v1/hub-managers")

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/feign/UserClient.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/feign/UserClient.java
@@ -1,7 +1,7 @@
 package com.firstlogistics.deliverservice.infrastructure.feign;
 
 import com.firstlogistics.deliverservice.infrastructure.feign.config.FeignErrorDecoder;
-import com.firstlogistics.deliverservice.infrastructure.feign.dto.FeignResponse;
+import com.firstlogistics.deliverservice.infrastructure.feign.dto.FeignApiResponse;
 import com.firstlogistics.deliverservice.application.port.dto.UserResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,10 +15,10 @@ import java.util.UUID;
 public interface UserClient {
 
 	@GetMapping("/api/v1/users/{userId}")
-	FeignResponse<UserResponse> getUser(@PathVariable("userId") UUID userId);
+	FeignApiResponse<UserResponse> getUser(@PathVariable("userId") UUID userId);
 
 	@GetMapping("/api/v1/users")
-	FeignResponse<List<UserResponse>> findByNameOrPhone(
+	FeignApiResponse<List<UserResponse>> findByNameOrPhone(
 		@RequestParam(value = "name", required = false) String name,
 		@RequestParam(value = "phone", required = false) String phone
 	);

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/feign/adapter/CompanyFeignAdapter.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/feign/adapter/CompanyFeignAdapter.java
@@ -2,10 +2,13 @@ package com.firstlogistics.deliverservice.infrastructure.feign.adapter;
 
 import com.firstlogistics.deliverservice.application.port.CompanyPort;
 import com.firstlogistics.deliverservice.application.port.dto.CompanyResponse;
+import com.firstlogistics.deliverservice.domain.exception.DeliveryErrorCode;
+import com.firstlogistics.deliverservice.domain.exception.DeliveryException;
 import com.firstlogistics.deliverservice.infrastructure.feign.CompanyClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.UUID;
 
 @Component
@@ -20,7 +23,11 @@ public class CompanyFeignAdapter implements CompanyPort {
 	}
 
 	@Override
-	public CompanyResponse getCompanyByManagerId(UUID managerId) {
-		return companyClient.getCompanyByManagerId(managerId).data();
+	public CompanyResponse getCompanyByUserId(UUID userId) {
+		List<CompanyResponse> results = companyClient.getCompaniesByUserId(userId).data();
+		if (results == null || results.size() != 1) {
+			throw new DeliveryException(DeliveryErrorCode.COMPANY_MANAGER_NOT_FOUND);
+		}
+		return results.get(0);
 	}
 }

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/feign/adapter/HubFeignAdapter.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/feign/adapter/HubFeignAdapter.java
@@ -17,8 +17,8 @@ public class HubFeignAdapter implements HubPort {
 	private final HubClient hubClient;
 
 	@Override
-	public HubRouteResponse getHubRoute(UUID sourceHubId, UUID destinationHubId) {
-		return hubClient.getHubRoute(sourceHubId, destinationHubId).data();
+	public HubRouteResponse getHubRoute(UUID sourceHubId, UUID destinationHubId, UUID receiverCompanyId) {
+		return hubClient.getHubRoute(sourceHubId, destinationHubId, receiverCompanyId).data();
 	}
 
 	@Override

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/feign/adapter/HubManagerFeignAdapter.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/feign/adapter/HubManagerFeignAdapter.java
@@ -2,10 +2,13 @@ package com.firstlogistics.deliverservice.infrastructure.feign.adapter;
 
 import com.firstlogistics.deliverservice.application.port.HubManagerPort;
 import com.firstlogistics.deliverservice.application.port.dto.HubManagerResponse;
+import com.firstlogistics.deliverservice.domain.exception.DeliveryErrorCode;
+import com.firstlogistics.deliverservice.domain.exception.DeliveryException;
 import com.firstlogistics.deliverservice.infrastructure.feign.HubClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.UUID;
 
 @Component
@@ -15,7 +18,11 @@ public class HubManagerFeignAdapter implements HubManagerPort {
 	private final HubClient hubClient;
 
 	@Override
-	public HubManagerResponse getHubManager(UUID managerId) {
-		return hubClient.getHubManager(managerId).data();
+	public HubManagerResponse getHubManager(UUID userId) {
+		List<HubManagerResponse> results = hubClient.getHubManagersByUserId(userId).data();
+		if (results == null || results.size() != 1) {
+			throw new DeliveryException(DeliveryErrorCode.HUB_MANAGER_NOT_FOUND);
+		}
+		return results.get(0);
 	}
 }

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/feign/adapter/HubManagerFeignAdapter.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/feign/adapter/HubManagerFeignAdapter.java
@@ -2,13 +2,10 @@ package com.firstlogistics.deliverservice.infrastructure.feign.adapter;
 
 import com.firstlogistics.deliverservice.application.port.HubManagerPort;
 import com.firstlogistics.deliverservice.application.port.dto.HubManagerResponse;
-import com.firstlogistics.deliverservice.domain.exception.DeliveryErrorCode;
-import com.firstlogistics.deliverservice.domain.exception.DeliveryException;
 import com.firstlogistics.deliverservice.infrastructure.feign.HubClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.UUID;
 
 @Component
@@ -19,10 +16,6 @@ public class HubManagerFeignAdapter implements HubManagerPort {
 
 	@Override
 	public HubManagerResponse getHubManager(UUID userId) {
-		List<HubManagerResponse> results = hubClient.getHubManagersByUserId(userId).data();
-		if (results == null || results.size() != 1) {
-			throw new DeliveryException(DeliveryErrorCode.HUB_MANAGER_NOT_FOUND);
-		}
-		return results.get(0);
+		return hubClient.getHubManagerByUserId(userId).data();
 	}
 }

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/feign/dto/FeignApiResponse.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/feign/dto/FeignApiResponse.java
@@ -3,5 +3,5 @@ package com.firstlogistics.deliverservice.infrastructure.feign.dto;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record FeignResponse<T>(T data) {
+public record FeignApiResponse<T>(T data) {
 }

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/messaging/producer/DeliveryEventKafkaProducer.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/messaging/producer/DeliveryEventKafkaProducer.java
@@ -2,6 +2,7 @@ package com.firstlogistics.deliverservice.infrastructure.messaging.producer;
 
 import com.firstlogistics.deliverservice.domain.event.DeliveryCreatedEvent;
 import com.firstlogistics.deliverservice.domain.event.DeliveryCreationFailedEvent;
+import com.firstlogistics.deliverservice.domain.event.DeliveryStatusChangedEvent;
 import com.firstlogistics.deliverservice.domain.event.DeliveryUpdatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +19,7 @@ public class DeliveryEventKafkaProducer {
 	private static final String TOPIC_CREATED = "delivery.created";
 	private static final String TOPIC_UPDATED = "delivery.updated";
 	private static final String TOPIC_CREATION_FAILED = "delivery.creation.failed";
+	private static final String TOPIC_STATUS_CHANGED = "delivery.status.changed";
 	private static final String TOPIC_ORDER_ACCEPTED_DLT = "order.accepted.DLT";
 
 	private final KafkaTemplate<String, Object> deliveryKafkaTemplate;
@@ -32,6 +34,12 @@ public class DeliveryEventKafkaProducer {
 	public void handleDeliveryUpdated(DeliveryUpdatedEvent event) {
 		deliveryKafkaTemplate.send(TOPIC_UPDATED, event.deliveryId().toString(), event);
 		log.info("이벤트 발행 - topic: {}, deliveryId: {}", TOPIC_UPDATED, event.deliveryId());
+	}
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handleDeliveryStatusChanged(DeliveryStatusChangedEvent event) {
+		deliveryKafkaTemplate.send(TOPIC_STATUS_CHANGED, event.deliveryId().toString(), event);
+		log.info("이벤트 발행 - topic: {}, deliveryId: {}, status: {}", TOPIC_STATUS_CHANGED, event.deliveryId(), event.status());
 	}
 
 	public void handleDeliveryCreationFailed(DeliveryCreationFailedEvent event) {

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/persistence/jpa/DeliveryManagerJpaRepository.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/persistence/jpa/DeliveryManagerJpaRepository.java
@@ -1,6 +1,7 @@
 package com.firstlogistics.deliverservice.infrastructure.persistence.jpa;
 
 import com.firstlogistics.deliverservice.domain.enums.ManagerType;
+import com.firstlogistics.deliverservice.domain.enums.TimetableStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -32,7 +33,7 @@ public interface DeliveryManagerJpaRepository extends JpaRepository<DeliveryMana
 		  AND NOT EXISTS (
 		      SELECT 1 FROM ManagerTimetableJpaEntity st2
 		      WHERE st2.deliveryManagerId = ds.id
-		        AND st2.status IN ('CREATED', 'HUB_MOVING')
+		        AND st2.status IN :activeStatuses
 		        AND st2.expectedStartAt < :assignmentEnd
 		        AND st2.expectedEndAt > :assignmentStart
 		  )
@@ -42,6 +43,7 @@ public interface DeliveryManagerJpaRepository extends JpaRepository<DeliveryMana
 	List<DeliveryManagerJpaEntity> findNextAvailableManager(
 		@Param("hubId") UUID hubId,
 		@Param("managerType") ManagerType managerType,
+		@Param("activeStatuses") List<TimetableStatus> activeStatuses,
 		@Param("assignmentStart") LocalDateTime assignmentStart,
 		@Param("assignmentEnd") LocalDateTime assignmentEnd,
 		Pageable pageable

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/persistence/jpa/DeliveryManagerRepositoryImpl.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/persistence/jpa/DeliveryManagerRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.firstlogistics.deliverservice.infrastructure.persistence.jpa;
 
 import com.firstlogistics.deliverservice.domain.entity.DeliveryManager;
 import com.firstlogistics.deliverservice.domain.enums.ManagerType;
+import com.firstlogistics.deliverservice.domain.enums.TimetableStatus;
 import com.firstlogistics.deliverservice.domain.repository.DeliveryManagerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -21,15 +22,17 @@ public class DeliveryManagerRepositoryImpl implements DeliveryManagerRepository 
 
 	@Override
 	public Optional<DeliveryManager> findNextHubDeliveryManager(UUID hubId, LocalDateTime assignmentStart, LocalDateTime assignmentEnd) {
+		List<TimetableStatus> activeStatuses = List.of(TimetableStatus.CREATED, TimetableStatus.HUB_MOVING);
 		List<DeliveryManagerJpaEntity> results = deliveryManagerJpaRepository
-			.findNextAvailableManager(hubId, ManagerType.HUB_DELIVERY, assignmentStart, assignmentEnd, PageRequest.of(0, 1));
+			.findNextAvailableManager(hubId, ManagerType.HUB_DELIVERY, activeStatuses, assignmentStart, assignmentEnd, PageRequest.of(0, 1));
 		return results.isEmpty() ? Optional.empty() : Optional.of(deliveryManagerMapper.toDomain(results.get(0)));
 	}
 
 	@Override
 	public Optional<DeliveryManager> findNextCompanyDeliveryManager(UUID hubId, LocalDateTime assignmentStart, LocalDateTime assignmentEnd) {
+		List<TimetableStatus> activeStatuses = List.of(TimetableStatus.CREATED, TimetableStatus.HUB_MOVING);
 		List<DeliveryManagerJpaEntity> results = deliveryManagerJpaRepository
-			.findNextAvailableManager(hubId, ManagerType.COMPANY_DELIVERY, assignmentStart, assignmentEnd, PageRequest.of(0, 1));
+			.findNextAvailableManager(hubId, ManagerType.COMPANY_DELIVERY, activeStatuses, assignmentStart, assignmentEnd, PageRequest.of(0, 1));
 		return results.isEmpty() ? Optional.empty() : Optional.of(deliveryManagerMapper.toDomain(results.get(0)));
 	}
 

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/presentation/DeliveryController.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/presentation/DeliveryController.java
@@ -71,7 +71,7 @@ public class DeliveryController {
 		@RequestHeader("X-User-Role") String role
 	) {
 		return ResponseEntity.ok(ApiResponse.success(DeliverySuccessCode.DELIVERY_STARTED,
-				ChangeDeliveryStatusResponse.from(deliveryCommandService.startDelivery(ChangeDeliveryStatusCommand.of(deliveryId, role, userId)))
+				ChangeDeliveryStatusResponse.from(deliveryCommandService.startHubDelivery(ChangeDeliveryStatusCommand.of(deliveryId, role, userId)))
 		));
 	}
 
@@ -104,7 +104,7 @@ public class DeliveryController {
 		@RequestHeader("X-User-Role") String role
 	) {
 		return ResponseEntity.ok(ApiResponse.success(DeliverySuccessCode.DELIVERY_COMPANY_STARTED,
-				ChangeDeliveryStatusResponse.from(deliveryCommandService.startDelivery(ChangeDeliveryStatusCommand.of(deliveryId, role, userId)))
+				ChangeDeliveryStatusResponse.from(deliveryCommandService.startCompanyDelivery(ChangeDeliveryStatusCommand.of(deliveryId, role, userId)))
 		));
 	}
 

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/presentation/DeliveryController.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/presentation/DeliveryController.java
@@ -8,6 +8,8 @@ import com.firstlogistics.deliverservice.presentation.dto.request.DeliveryListRe
 import com.firstlogistics.deliverservice.presentation.dto.request.UpdateDeliveryRequest;
 import com.firstlogistics.deliverservice.presentation.dto.response.DeliveryDetailResponse;
 import com.firstlogistics.deliverservice.presentation.dto.response.DeliveryListResponse;
+import com.firstlogistics.deliverservice.application.dto.command.ChangeDeliveryStatusCommand;
+import com.firstlogistics.deliverservice.presentation.dto.response.ChangeDeliveryStatusResponse;
 import com.firstlogistics.deliverservice.presentation.dto.response.CreateDeliveryResponse;
 import com.firstlogistics.deliverservice.presentation.dto.response.UpdateDeliveryResponse;
 import common.response.ApiResponse;
@@ -59,6 +61,61 @@ public class DeliveryController {
 	) {
 		return ResponseEntity.ok(ApiResponse.success(DeliverySuccessCode.DELIVERY_UPDATED,
 				UpdateDeliveryResponse.from(deliveryCommandService.updateDelivery(request.toCommand(deliveryId, role, userId)))
+		));
+	}
+
+	@PostMapping("/{deliveryId}/start")
+	public ResponseEntity<ApiResponse<ChangeDeliveryStatusResponse>> startDelivery(
+		@PathVariable UUID deliveryId,
+		@RequestHeader("X-User-Id") UUID userId,
+		@RequestHeader("X-User-Role") String role
+	) {
+		return ResponseEntity.ok(ApiResponse.success(DeliverySuccessCode.DELIVERY_STARTED,
+				ChangeDeliveryStatusResponse.from(deliveryCommandService.startDelivery(ChangeDeliveryStatusCommand.of(deliveryId, role, userId)))
+		));
+	}
+
+	@PostMapping("/{deliveryId}/arrive-hub")
+	public ResponseEntity<ApiResponse<ChangeDeliveryStatusResponse>> arriveHub(
+		@PathVariable UUID deliveryId,
+		@RequestHeader("X-User-Id") UUID userId,
+		@RequestHeader("X-User-Role") String role
+	) {
+		return ResponseEntity.ok(ApiResponse.success(DeliverySuccessCode.DELIVERY_HUB_ARRIVED,
+				ChangeDeliveryStatusResponse.from(deliveryCommandService.arriveHub(ChangeDeliveryStatusCommand.of(deliveryId, role, userId)))
+		));
+	}
+
+	@PostMapping("/{deliveryId}/receive-hub")
+	public ResponseEntity<ApiResponse<ChangeDeliveryStatusResponse>> receiveAtHub(
+		@PathVariable UUID deliveryId,
+		@RequestHeader("X-User-Id") UUID userId,
+		@RequestHeader("X-User-Role") String role
+	) {
+		return ResponseEntity.ok(ApiResponse.success(DeliverySuccessCode.DELIVERY_RECEIVED,
+				ChangeDeliveryStatusResponse.from(deliveryCommandService.receiveAtHub(ChangeDeliveryStatusCommand.of(deliveryId, role, userId)))
+		));
+	}
+
+	@PostMapping("/{deliveryId}/start-company")
+	public ResponseEntity<ApiResponse<ChangeDeliveryStatusResponse>> startCompanyDelivery(
+		@PathVariable UUID deliveryId,
+		@RequestHeader("X-User-Id") UUID userId,
+		@RequestHeader("X-User-Role") String role
+	) {
+		return ResponseEntity.ok(ApiResponse.success(DeliverySuccessCode.DELIVERY_COMPANY_STARTED,
+				ChangeDeliveryStatusResponse.from(deliveryCommandService.startDelivery(ChangeDeliveryStatusCommand.of(deliveryId, role, userId)))
+		));
+	}
+
+	@PostMapping("/{deliveryId}/complete")
+	public ResponseEntity<ApiResponse<ChangeDeliveryStatusResponse>> completeDelivery(
+		@PathVariable UUID deliveryId,
+		@RequestHeader("X-User-Id") UUID userId,
+		@RequestHeader("X-User-Role") String role
+	) {
+		return ResponseEntity.ok(ApiResponse.success(DeliverySuccessCode.DELIVERY_COMPLETED,
+				ChangeDeliveryStatusResponse.from(deliveryCommandService.completeDelivery(ChangeDeliveryStatusCommand.of(deliveryId, role, userId)))
 		));
 	}
 

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/presentation/DeliverySuccessCode.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/presentation/DeliverySuccessCode.java
@@ -12,7 +12,12 @@ public enum DeliverySuccessCode implements SuccessCode {
 	DELIVERY_CREATED(HttpStatus.CREATED, "DR_S001", "배송이 생성되었습니다."),
 	DELIVERY_LIST_FOUND(HttpStatus.OK, "DR_S002", "배송 목록 조회에 성공하였습니다."),
 	DELIVERY_DETAIL_FOUND(HttpStatus.OK, "DR_S003", "배송 상세 조회에 성공하였습니다."),
-	DELIVERY_UPDATED(HttpStatus.OK, "DR_S004", "배송 정보가 수정되었습니다.");
+	DELIVERY_UPDATED(HttpStatus.OK, "DR_S004", "배송 정보가 수정되었습니다."),
+	DELIVERY_STARTED(HttpStatus.OK, "DR_S005", "배송이 시작되었습니다."),
+	DELIVERY_HUB_ARRIVED(HttpStatus.OK, "DR_S006", "허브에 도착하였습니다."),
+	DELIVERY_COMPANY_STARTED(HttpStatus.OK, "DR_S007", "업체 배송이 시작되었습니다."),
+	DELIVERY_COMPLETED(HttpStatus.OK, "DR_S008", "배송이 완료되었습니다."),
+	DELIVERY_RECEIVED(HttpStatus.OK, "DR_S009", "입고가 완료되었습니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/presentation/dto/response/ChangeDeliveryStatusResponse.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/presentation/dto/response/ChangeDeliveryStatusResponse.java
@@ -1,0 +1,13 @@
+package com.firstlogistics.deliverservice.presentation.dto.response;
+
+import com.firstlogistics.deliverservice.application.dto.result.ChangeDeliveryStatusResult;
+
+import java.util.UUID;
+
+public record ChangeDeliveryStatusResponse(
+	UUID deliveryId
+) {
+	public static ChangeDeliveryStatusResponse from(ChangeDeliveryStatusResult result) {
+		return new ChangeDeliveryStatusResponse(result.deliveryId());
+	}
+}

--- a/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/DeliveryCommandServiceTest.java
+++ b/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/DeliveryCommandServiceTest.java
@@ -548,12 +548,12 @@ class DeliveryCommandServiceTest {
 	// ===== 배송 상태 변경 테스트 =====
 
 	@Nested
-	@DisplayName("배송 시작 실패")
-	class StartDeliveryFail {
+	@DisplayName("허브 배송 시작 실패")
+	class StartHubDeliveryFail {
 
 		@Test
 		@DisplayName("존재하지 않는 배송")
-		void startDelivery_fail_deliveryNotFound() {
+		void startHubDelivery_fail_deliveryNotFound() {
 			// given
 			UUID deliveryId = UUID.randomUUID();
 			UUID userId = UUID.randomUUID();
@@ -562,7 +562,7 @@ class DeliveryCommandServiceTest {
 			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.empty());
 
 			// when
-			Throwable throwable = catchThrowable(() -> deliveryCommandService.startDelivery(command));
+			Throwable throwable = catchThrowable(() -> deliveryCommandService.startHubDelivery(command));
 			log.info("throwable = {}", throwable.getMessage());
 
 			// then
@@ -573,7 +573,7 @@ class DeliveryCommandServiceTest {
 
 		@Test
 		@DisplayName("권한 없음 (COMPANY_MANAGER)")
-		void startDelivery_fail_accessDenied() {
+		void startHubDelivery_fail_accessDenied() {
 			// given
 			UUID deliveryId = UUID.randomUUID();
 			UUID userId = UUID.randomUUID();
@@ -585,7 +585,7 @@ class DeliveryCommandServiceTest {
 				.given(deliveryPermissionValidator).validate(any(), eq("COMPANY_MANAGER"), eq(userId), any());
 
 			// when
-			Throwable throwable = catchThrowable(() -> deliveryCommandService.startDelivery(command));
+			Throwable throwable = catchThrowable(() -> deliveryCommandService.startHubDelivery(command));
 			log.info("throwable = {}", throwable.getMessage());
 
 			// then
@@ -595,8 +595,8 @@ class DeliveryCommandServiceTest {
 		}
 
 		@Test
-		@DisplayName("잘못된 상태 (HUB_MOVING)")
-		void startDelivery_fail_invalidStatus() {
+		@DisplayName("잘못된 상태 (FOR_HUB_MOVING)")
+		void startHubDelivery_fail_invalidStatus() {
 			// given
 			UUID deliveryId = UUID.randomUUID();
 			UUID userId = UUID.randomUUID();
@@ -606,7 +606,7 @@ class DeliveryCommandServiceTest {
 			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
 
 			// when
-			Throwable throwable = catchThrowable(() -> deliveryCommandService.startDelivery(command));
+			Throwable throwable = catchThrowable(() -> deliveryCommandService.startHubDelivery(command));
 			log.info("throwable = {}", throwable.getMessage());
 
 			// then
@@ -617,12 +617,12 @@ class DeliveryCommandServiceTest {
 	}
 
 	@Nested
-	@DisplayName("배송 시작 성공")
-	class StartDeliverySuccess {
+	@DisplayName("허브 배송 시작 성공")
+	class StartHubDeliverySuccess {
 
 		@Test
 		@DisplayName("CREATED 상태에서 시작")
-		void startDelivery_success_fromCreated() {
+		void startHubDelivery_success_fromCreated() {
 			// given
 			UUID deliveryId = UUID.randomUUID();
 			UUID userId = UUID.randomUUID();
@@ -633,7 +633,7 @@ class DeliveryCommandServiceTest {
 			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
 
 			// when
-			ChangeDeliveryStatusResult result = deliveryCommandService.startDelivery(command);
+			ChangeDeliveryStatusResult result = deliveryCommandService.startHubDelivery(command);
 
 			// then
 			assertThat(result.deliveryId()).isEqualTo(deliveryId);
@@ -644,7 +644,7 @@ class DeliveryCommandServiceTest {
 
 		@Test
 		@DisplayName("HUB_WAITING 상태에서 시작 (경유지 출발)")
-		void startDelivery_success_fromHubWaiting() {
+		void startHubDelivery_success_fromHubWaiting() {
 			// given
 			UUID deliveryId = UUID.randomUUID();
 			UUID userId = UUID.randomUUID();
@@ -655,7 +655,7 @@ class DeliveryCommandServiceTest {
 			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
 
 			// when
-			ChangeDeliveryStatusResult result = deliveryCommandService.startDelivery(command);
+			ChangeDeliveryStatusResult result = deliveryCommandService.startHubDelivery(command);
 
 			// then
 			assertThat(result.deliveryId()).isEqualTo(deliveryId);
@@ -666,7 +666,7 @@ class DeliveryCommandServiceTest {
 
 		@Test
 		@DisplayName("시작 시 경로 상태 변경 및 이벤트 발행")
-		void startDelivery_success_routeStatusAndEvent() {
+		void startHubDelivery_success_routeStatusAndEvent() {
 			// given
 			UUID deliveryId = UUID.randomUUID();
 			UUID userId = UUID.randomUUID();
@@ -677,7 +677,7 @@ class DeliveryCommandServiceTest {
 			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
 
 			// when
-			deliveryCommandService.startDelivery(command);
+			deliveryCommandService.startHubDelivery(command);
 
 			// then
 			assertThat(delivery.getRoutes().get(0).getStatus()).isEqualTo(RouteStatus.MOVING);
@@ -893,12 +893,12 @@ class DeliveryCommandServiceTest {
 	}
 
 	@Nested
-	@DisplayName("마지막 허브에서 배송 시작 (업체 배송)")
-	class StartDeliveryAtFinalHub {
+	@DisplayName("업체 배송 시작 성공")
+	class StartCompanyDeliverySuccess {
 
 		@Test
 		@DisplayName("HUB_WAITING + 마지막 허브 → FOR_COMPANY_MOVING")
-		void startDelivery_success_lastHub_forCompanyMoving() {
+		void startCompanyDelivery_success() {
 			// given
 			UUID deliveryId = UUID.randomUUID();
 			UUID userId = UUID.randomUUID();
@@ -909,7 +909,7 @@ class DeliveryCommandServiceTest {
 			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
 
 			// when
-			ChangeDeliveryStatusResult result = deliveryCommandService.startDelivery(command);
+			ChangeDeliveryStatusResult result = deliveryCommandService.startCompanyDelivery(command);
 
 			// then
 			assertThat(result.deliveryId()).isEqualTo(deliveryId);
@@ -920,7 +920,7 @@ class DeliveryCommandServiceTest {
 
 		@Test
 		@DisplayName("업체 배송 시작 시 이벤트 발행")
-		void startDelivery_success_lastHub_eventPublished() {
+		void startCompanyDelivery_success_eventPublished() {
 			// given
 			UUID deliveryId = UUID.randomUUID();
 			UUID userId = UUID.randomUUID();
@@ -931,7 +931,7 @@ class DeliveryCommandServiceTest {
 			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
 
 			// when
-			deliveryCommandService.startDelivery(command);
+			deliveryCommandService.startCompanyDelivery(command);
 
 			// then
 			ArgumentCaptor<DeliveryStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(DeliveryStatusChangedEvent.class);
@@ -978,7 +978,7 @@ class DeliveryCommandServiceTest {
 			// given
 			UUID deliveryId = UUID.randomUUID();
 			UUID userId = UUID.randomUUID();
-			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.FOR_COMPANY_MOVING);
+			Delivery delivery = stubCompanyMovingDelivery(deliveryId);
 			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
 
 			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
@@ -1000,7 +1000,7 @@ class DeliveryCommandServiceTest {
 			// given
 			UUID deliveryId = UUID.randomUUID();
 			UUID userId = UUID.randomUUID();
-			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.FOR_COMPANY_MOVING);
+			Delivery delivery = stubCompanyMovingDelivery(deliveryId);
 			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
 
 			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
@@ -1104,6 +1104,25 @@ class DeliveryCommandServiceTest {
 			UUID.randomUUID(), "slack-receiver", UUID.randomUUID(),
 			DeliveryManagerId.generate(), STUB_MIDDLE_HUB_ID,
 			List.of(route1, route2)
+		);
+	}
+
+	private Delivery stubCompanyMovingDelivery(UUID deliveryId) {
+		DeliveryId id = DeliveryId.of(deliveryId);
+		DeliveryRoute route = DeliveryRoute.reconstitute(
+			DeliveryRouteId.generate(), id, 0,
+			STUB_SOURCE_HUB_ID, STUB_DESTINATION_HUB_ID,
+			Distance.of(10000), Time.of(30), null, null, null, null,
+			RouteStatus.MOVING, STUB_ROUTE_MANAGER_ID
+		);
+		return Delivery.reconstitute(
+			id, UUID.randomUUID(), DeliveryStatus.FOR_COMPANY_MOVING,
+			STUB_SOURCE_HUB_ID, STUB_DESTINATION_HUB_ID,
+			Address.of("서울시 강남구 테헤란로 123", "101호"),
+			null,
+			UUID.randomUUID(), "slack-receiver", UUID.randomUUID(),
+			DeliveryManagerId.generate(), STUB_DESTINATION_HUB_ID,
+			List.of(route)
 		);
 	}
 

--- a/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/DeliveryCommandServiceTest.java
+++ b/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/DeliveryCommandServiceTest.java
@@ -893,6 +893,96 @@ class DeliveryCommandServiceTest {
 	}
 
 	@Nested
+	@DisplayName("업체 배송 시작 실패")
+	class StartCompanyDeliveryFail {
+
+		@Test
+		@DisplayName("존재하지 않는 배송")
+		void startCompanyDelivery_fail_deliveryNotFound() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.empty());
+
+			// when
+			Throwable throwable = catchThrowable(() -> deliveryCommandService.startCompanyDelivery(command));
+			log.info("throwable = {}", throwable.getMessage());
+
+			// then
+			assertThat(throwable)
+				.isInstanceOf(DeliveryException.class)
+				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.DELIVERY_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("권한 없음 (COMPANY_MANAGER)")
+		void startCompanyDelivery_fail_accessDenied() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryAtFinalHub(deliveryId);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "COMPANY_MANAGER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+			willThrow(new DeliveryException(DeliveryErrorCode.DELIVERY_ACCESS_DENIED))
+				.given(deliveryPermissionValidator).validate(any(), eq("COMPANY_MANAGER"), eq(userId), any());
+
+			// when
+			Throwable throwable = catchThrowable(() -> deliveryCommandService.startCompanyDelivery(command));
+			log.info("throwable = {}", throwable.getMessage());
+
+			// then
+			assertThat(throwable)
+				.isInstanceOf(DeliveryException.class)
+				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.DELIVERY_ACCESS_DENIED);
+		}
+
+		@Test
+		@DisplayName("잘못된 상태 (CREATED)")
+		void startCompanyDelivery_fail_invalidStatus() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.CREATED);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+
+			// when
+			Throwable throwable = catchThrowable(() -> deliveryCommandService.startCompanyDelivery(command));
+			log.info("throwable = {}", throwable.getMessage());
+
+			// then
+			assertThat(throwable)
+				.isInstanceOf(DeliveryException.class)
+				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.INVALID_STATUS_TRANSITION);
+		}
+
+		@Test
+		@DisplayName("마지막 허브가 아닌데 업체 배송 시작 시도")
+		void startCompanyDelivery_fail_notAtFinalHub() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryWithMultipleRoutes(deliveryId, DeliveryStatus.HUB_WAITING);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+
+			// when
+			Throwable throwable = catchThrowable(() -> deliveryCommandService.startCompanyDelivery(command));
+			log.info("throwable = {}", throwable.getMessage());
+
+			// then
+			assertThat(throwable)
+				.isInstanceOf(DeliveryException.class)
+				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.NOT_COMPANY_DELIVERY_PHASE);
+		}
+	}
+
+	@Nested
 	@DisplayName("업체 배송 시작 성공")
 	class StartCompanyDeliverySuccess {
 

--- a/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/DeliveryCommandServiceTest.java
+++ b/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/DeliveryCommandServiceTest.java
@@ -1,7 +1,9 @@
 package com.firstlogistics.deliverservice.application;
 
+import com.firstlogistics.deliverservice.application.dto.command.ChangeDeliveryStatusCommand;
 import com.firstlogistics.deliverservice.application.dto.command.CreateDeliveryCommand;
 import com.firstlogistics.deliverservice.application.dto.command.UpdateDeliveryCommand;
+import com.firstlogistics.deliverservice.application.dto.result.ChangeDeliveryStatusResult;
 import com.firstlogistics.deliverservice.application.dto.result.UpdateDeliveryResult;
 import com.firstlogistics.deliverservice.application.publisher.DeliveryEventPublisher;
 import com.firstlogistics.deliverservice.domain.entity.Delivery;
@@ -10,6 +12,8 @@ import com.firstlogistics.deliverservice.domain.entity.DeliveryRoute;
 import com.firstlogistics.deliverservice.domain.enums.DeliveryStatus;
 import com.firstlogistics.deliverservice.domain.enums.ManagerType;
 import com.firstlogistics.deliverservice.domain.enums.TimetableStatus;
+import com.firstlogistics.deliverservice.domain.enums.RouteStatus;
+import com.firstlogistics.deliverservice.domain.event.DeliveryStatusChangedEvent;
 import com.firstlogistics.deliverservice.domain.event.DeliveryUpdatedEvent;
 import com.firstlogistics.deliverservice.domain.exception.DeliveryErrorCode;
 import com.firstlogistics.deliverservice.domain.exception.DeliveryException;
@@ -18,6 +22,9 @@ import com.firstlogistics.deliverservice.domain.repository.DeliveryManagerReposi
 import com.firstlogistics.deliverservice.domain.vo.Address;
 import com.firstlogistics.deliverservice.domain.vo.DeliveryId;
 import com.firstlogistics.deliverservice.domain.vo.DeliveryManagerId;
+import com.firstlogistics.deliverservice.domain.vo.DeliveryRouteId;
+import com.firstlogistics.deliverservice.domain.vo.Distance;
+import com.firstlogistics.deliverservice.domain.vo.Time;
 import com.firstlogistics.deliverservice.application.permission.DeliveryPermissionValidator;
 import com.firstlogistics.deliverservice.application.port.HubPort;
 import com.firstlogistics.deliverservice.application.port.UserPort;
@@ -402,7 +409,7 @@ class DeliveryCommandServiceTest {
 			// given
 			UUID deliveryId = UUID.randomUUID();
 			UUID userId = UUID.randomUUID();
-			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.HUB_MOVING);
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.FOR_HUB_MOVING);
 			UpdateDeliveryCommand command = new UpdateDeliveryCommand(deliveryId, "MASTER", userId, UUID.randomUUID(), null);
 
 			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
@@ -538,9 +545,483 @@ class DeliveryCommandServiceTest {
 		}
 	}
 
+	// ===== 배송 상태 변경 테스트 =====
+
+	@Nested
+	@DisplayName("배송 시작 실패")
+	class StartDeliveryFail {
+
+		@Test
+		@DisplayName("존재하지 않는 배송")
+		void startDelivery_fail_deliveryNotFound() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.empty());
+
+			// when
+			Throwable throwable = catchThrowable(() -> deliveryCommandService.startDelivery(command));
+			log.info("throwable = {}", throwable.getMessage());
+
+			// then
+			assertThat(throwable)
+				.isInstanceOf(DeliveryException.class)
+				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.DELIVERY_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("권한 없음 (COMPANY_MANAGER)")
+		void startDelivery_fail_accessDenied() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.CREATED);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "COMPANY_MANAGER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+			willThrow(new DeliveryException(DeliveryErrorCode.DELIVERY_ACCESS_DENIED))
+				.given(deliveryPermissionValidator).validate(any(), eq("COMPANY_MANAGER"), eq(userId), any());
+
+			// when
+			Throwable throwable = catchThrowable(() -> deliveryCommandService.startDelivery(command));
+			log.info("throwable = {}", throwable.getMessage());
+
+			// then
+			assertThat(throwable)
+				.isInstanceOf(DeliveryException.class)
+				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.DELIVERY_ACCESS_DENIED);
+		}
+
+		@Test
+		@DisplayName("잘못된 상태 (HUB_MOVING)")
+		void startDelivery_fail_invalidStatus() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.FOR_HUB_MOVING);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+
+			// when
+			Throwable throwable = catchThrowable(() -> deliveryCommandService.startDelivery(command));
+			log.info("throwable = {}", throwable.getMessage());
+
+			// then
+			assertThat(throwable)
+				.isInstanceOf(DeliveryException.class)
+				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.INVALID_STATUS_TRANSITION);
+		}
+	}
+
+	@Nested
+	@DisplayName("배송 시작 성공")
+	class StartDeliverySuccess {
+
+		@Test
+		@DisplayName("CREATED 상태에서 시작")
+		void startDelivery_success_fromCreated() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.CREATED);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
+
+			// when
+			ChangeDeliveryStatusResult result = deliveryCommandService.startDelivery(command);
+
+			// then
+			assertThat(result.deliveryId()).isEqualTo(deliveryId);
+			ArgumentCaptor<Delivery> captor = ArgumentCaptor.forClass(Delivery.class);
+			then(deliveryRepository).should().save(captor.capture());
+			assertThat(captor.getValue().getStatus()).isEqualTo(DeliveryStatus.FOR_HUB_MOVING);
+		}
+
+		@Test
+		@DisplayName("HUB_WAITING 상태에서 시작 (경유지 출발)")
+		void startDelivery_success_fromHubWaiting() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryWithMultipleRoutes(deliveryId, DeliveryStatus.HUB_WAITING);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
+
+			// when
+			ChangeDeliveryStatusResult result = deliveryCommandService.startDelivery(command);
+
+			// then
+			assertThat(result.deliveryId()).isEqualTo(deliveryId);
+			ArgumentCaptor<Delivery> captor = ArgumentCaptor.forClass(Delivery.class);
+			then(deliveryRepository).should().save(captor.capture());
+			assertThat(captor.getValue().getStatus()).isEqualTo(DeliveryStatus.FOR_HUB_MOVING);
+		}
+
+		@Test
+		@DisplayName("시작 시 경로 상태 변경 및 이벤트 발행")
+		void startDelivery_success_routeStatusAndEvent() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.CREATED);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
+
+			// when
+			deliveryCommandService.startDelivery(command);
+
+			// then
+			assertThat(delivery.getRoutes().get(0).getStatus()).isEqualTo(RouteStatus.MOVING);
+			ArgumentCaptor<DeliveryStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(DeliveryStatusChangedEvent.class);
+			then(deliveryEventPublisher).should().publishDeliveryStatusChanged(eventCaptor.capture());
+			DeliveryStatusChangedEvent captured = eventCaptor.getValue();
+			assertThat(captured.status()).isEqualTo("FOR_HUB_MOVING");
+			assertThat(captured.deliveryId()).isEqualTo(deliveryId);
+			assertThat(captured.sourceHubId()).isEqualTo(STUB_SOURCE_HUB_ID);
+			assertThat(captured.destinationHubId()).isEqualTo(STUB_DESTINATION_HUB_ID);
+			assertThat(captured.routes()).hasSize(1);
+		}
+	}
+
+	@Nested
+	@DisplayName("허브 도착 실패")
+	class ArriveHubFail {
+
+		@Test
+		@DisplayName("존재하지 않는 배송")
+		void arriveHub_fail_deliveryNotFound() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.empty());
+
+			// when
+			Throwable throwable = catchThrowable(() -> deliveryCommandService.arriveHub(command));
+			log.info("throwable = {}", throwable.getMessage());
+
+			// then
+			assertThat(throwable)
+				.isInstanceOf(DeliveryException.class)
+				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.DELIVERY_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("잘못된 상태 (HUB_WAITING)")
+		void arriveHub_fail_invalidStatus() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.HUB_WAITING);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+
+			// when
+			Throwable throwable = catchThrowable(() -> deliveryCommandService.arriveHub(command));
+			log.info("throwable = {}", throwable.getMessage());
+
+			// then
+			assertThat(throwable)
+				.isInstanceOf(DeliveryException.class)
+				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.INVALID_STATUS_TRANSITION);
+		}
+	}
+
+	@Nested
+	@DisplayName("허브 도착 성공")
+	class ArriveHubSuccess {
+
+		@Test
+		@DisplayName("중간 허브 도착 → HUB_ARRIVED + currentHubId 업데이트")
+		void arriveHub_success_intermediateHub() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubMovingDeliveryWithMultipleRoutes(deliveryId);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
+
+			// when
+			ChangeDeliveryStatusResult result = deliveryCommandService.arriveHub(command);
+
+			// then
+			assertThat(result.deliveryId()).isEqualTo(deliveryId);
+			ArgumentCaptor<Delivery> captor = ArgumentCaptor.forClass(Delivery.class);
+			then(deliveryRepository).should().save(captor.capture());
+			Delivery saved = captor.getValue();
+			assertThat(saved.getStatus()).isEqualTo(DeliveryStatus.HUB_ARRIVED);
+			assertThat(saved.getCurrentHubId()).isEqualTo(STUB_MIDDLE_HUB_ID);
+		}
+
+		@Test
+		@DisplayName("최종 허브 도착 → HUB_ARRIVED + currentHubId 업데이트")
+		void arriveHub_success_finalHub() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubMovingDeliveryLastRoute(deliveryId);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
+
+			// when
+			ChangeDeliveryStatusResult result = deliveryCommandService.arriveHub(command);
+
+			// then
+			assertThat(result.deliveryId()).isEqualTo(deliveryId);
+			ArgumentCaptor<Delivery> captor = ArgumentCaptor.forClass(Delivery.class);
+			then(deliveryRepository).should().save(captor.capture());
+			Delivery saved = captor.getValue();
+			assertThat(saved.getStatus()).isEqualTo(DeliveryStatus.HUB_ARRIVED);
+			assertThat(saved.getCurrentHubId()).isEqualTo(STUB_DESTINATION_HUB_ID);
+		}
+
+		@Test
+		@DisplayName("허브 도착 시 이벤트 발행")
+		void arriveHub_success_eventPublished() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubMovingDeliveryLastRoute(deliveryId);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
+
+			// when
+			deliveryCommandService.arriveHub(command);
+
+			// then
+			ArgumentCaptor<DeliveryStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(DeliveryStatusChangedEvent.class);
+			then(deliveryEventPublisher).should().publishDeliveryStatusChanged(eventCaptor.capture());
+			DeliveryStatusChangedEvent captured = eventCaptor.getValue();
+			assertThat(captured.status()).isEqualTo("HUB_ARRIVED");
+			assertThat(captured.deliveryId()).isEqualTo(deliveryId);
+			assertThat(captured.routes()).hasSize(2);
+		}
+	}
+
+	@Nested
+	@DisplayName("입고 완료 실패")
+	class ReceiveAtHubFail {
+
+		@Test
+		@DisplayName("잘못된 상태 (HUB_WAITING)")
+		void receiveAtHub_fail_invalidStatus() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.HUB_WAITING);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+
+			// when
+			Throwable throwable = catchThrowable(() -> deliveryCommandService.receiveAtHub(command));
+			log.info("throwable = {}", throwable.getMessage());
+
+			// then
+			assertThat(throwable)
+				.isInstanceOf(DeliveryException.class)
+				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.INVALID_STATUS_TRANSITION);
+		}
+	}
+
+	@Nested
+	@DisplayName("입고 완료 성공")
+	class ReceiveAtHubSuccess {
+
+		@Test
+		@DisplayName("HUB_ARRIVED → HUB_WAITING")
+		void receiveAtHub_success() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.HUB_ARRIVED);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
+
+			// when
+			ChangeDeliveryStatusResult result = deliveryCommandService.receiveAtHub(command);
+
+			// then
+			assertThat(result.deliveryId()).isEqualTo(deliveryId);
+			ArgumentCaptor<Delivery> captor = ArgumentCaptor.forClass(Delivery.class);
+			then(deliveryRepository).should().save(captor.capture());
+			assertThat(captor.getValue().getStatus()).isEqualTo(DeliveryStatus.HUB_WAITING);
+		}
+
+		@Test
+		@DisplayName("입고 완료 시 이벤트 발행")
+		void receiveAtHub_success_eventPublished() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.HUB_ARRIVED);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
+
+			// when
+			deliveryCommandService.receiveAtHub(command);
+
+			// then
+			ArgumentCaptor<DeliveryStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(DeliveryStatusChangedEvent.class);
+			then(deliveryEventPublisher).should().publishDeliveryStatusChanged(eventCaptor.capture());
+			DeliveryStatusChangedEvent captured = eventCaptor.getValue();
+			assertThat(captured.status()).isEqualTo("HUB_WAITING");
+			assertThat(captured.deliveryId()).isEqualTo(deliveryId);
+		}
+
+	}
+
+	@Nested
+	@DisplayName("마지막 허브에서 배송 시작 (업체 배송)")
+	class StartDeliveryAtFinalHub {
+
+		@Test
+		@DisplayName("HUB_WAITING + 마지막 허브 → FOR_COMPANY_MOVING")
+		void startDelivery_success_lastHub_forCompanyMoving() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryAtFinalHub(deliveryId);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
+
+			// when
+			ChangeDeliveryStatusResult result = deliveryCommandService.startDelivery(command);
+
+			// then
+			assertThat(result.deliveryId()).isEqualTo(deliveryId);
+			ArgumentCaptor<Delivery> captor = ArgumentCaptor.forClass(Delivery.class);
+			then(deliveryRepository).should().save(captor.capture());
+			assertThat(captor.getValue().getStatus()).isEqualTo(DeliveryStatus.FOR_COMPANY_MOVING);
+		}
+
+		@Test
+		@DisplayName("업체 배송 시작 시 이벤트 발행")
+		void startDelivery_success_lastHub_eventPublished() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryAtFinalHub(deliveryId);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
+
+			// when
+			deliveryCommandService.startDelivery(command);
+
+			// then
+			ArgumentCaptor<DeliveryStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(DeliveryStatusChangedEvent.class);
+			then(deliveryEventPublisher).should().publishDeliveryStatusChanged(eventCaptor.capture());
+			DeliveryStatusChangedEvent captured = eventCaptor.getValue();
+			assertThat(captured.status()).isEqualTo("FOR_COMPANY_MOVING");
+			assertThat(captured.deliveryId()).isEqualTo(deliveryId);
+		}
+	}
+
+	@Nested
+	@DisplayName("배송 완료 실패")
+	class CompleteDeliveryFail {
+
+		@Test
+		@DisplayName("잘못된 상태 (HUB_ARRIVED)")
+		void completeDelivery_fail_invalidStatus() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.HUB_ARRIVED);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+
+			// when
+			Throwable throwable = catchThrowable(() -> deliveryCommandService.completeDelivery(command));
+			log.info("throwable = {}", throwable.getMessage());
+
+			// then
+			assertThat(throwable)
+				.isInstanceOf(DeliveryException.class)
+				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.INVALID_STATUS_TRANSITION);
+		}
+	}
+
+	@Nested
+	@DisplayName("배송 완료 성공")
+	class CompleteDeliverySuccess {
+
+		@Test
+		@DisplayName("FOR_COMPANY_MOVING → COMPLETED")
+		void completeDelivery_success() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.FOR_COMPANY_MOVING);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
+
+			// when
+			ChangeDeliveryStatusResult result = deliveryCommandService.completeDelivery(command);
+
+			// then
+			assertThat(result.deliveryId()).isEqualTo(deliveryId);
+			ArgumentCaptor<Delivery> captor = ArgumentCaptor.forClass(Delivery.class);
+			then(deliveryRepository).should().save(captor.capture());
+			assertThat(captor.getValue().getStatus()).isEqualTo(DeliveryStatus.COMPLETED);
+		}
+
+		@Test
+		@DisplayName("배송 완료 시 이벤트 발행")
+		void completeDelivery_success_eventPublished() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.FOR_COMPANY_MOVING);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
+
+			// when
+			deliveryCommandService.completeDelivery(command);
+
+			// then
+			ArgumentCaptor<DeliveryStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(DeliveryStatusChangedEvent.class);
+			then(deliveryEventPublisher).should().publishDeliveryStatusChanged(eventCaptor.capture());
+			DeliveryStatusChangedEvent captured = eventCaptor.getValue();
+			assertThat(captured.status()).isEqualTo("COMPLETED");
+			assertThat(captured.deliveryId()).isEqualTo(deliveryId);
+		}
+	}
+
 	// --- 배송 수정 테스트 픽스처 ---
 
 	private static final UUID STUB_SOURCE_HUB_ID = UUID.randomUUID();
+	private static final UUID STUB_MIDDLE_HUB_ID = UUID.randomUUID();
 	private static final UUID STUB_DESTINATION_HUB_ID = UUID.randomUUID();
 	private static final DeliveryManagerId STUB_ROUTE_MANAGER_ID = DeliveryManagerId.generate();
 
@@ -556,6 +1037,94 @@ class DeliveryCommandServiceTest {
 			UUID.randomUUID(), "slack-receiver", UUID.randomUUID(),
 			DeliveryManagerId.generate(), STUB_SOURCE_HUB_ID,
 			List.of(route)
+		);
+	}
+
+	private Delivery stubDeliveryWithMultipleRoutes(UUID deliveryId, DeliveryStatus status) {
+		DeliveryId id = DeliveryId.of(deliveryId);
+		DeliveryRoute route1 = DeliveryRoute.reconstitute(
+			DeliveryRouteId.generate(), id, 0,
+			STUB_SOURCE_HUB_ID, STUB_MIDDLE_HUB_ID,
+			Distance.of(10000), Time.of(30), null, null, null, null,
+			RouteStatus.ARRIVED, STUB_ROUTE_MANAGER_ID
+		);
+		DeliveryRoute route2 = DeliveryRoute.create(id, 1, STUB_MIDDLE_HUB_ID, STUB_DESTINATION_HUB_ID, 8000, 25);
+		route2.assignManager(STUB_ROUTE_MANAGER_ID);
+		return Delivery.reconstitute(
+			id, UUID.randomUUID(), status,
+			STUB_SOURCE_HUB_ID, STUB_DESTINATION_HUB_ID,
+			Address.of("서울시 강남구 테헤란로 123", "101호"),
+			null,
+			UUID.randomUUID(), "slack-receiver", UUID.randomUUID(),
+			DeliveryManagerId.generate(), STUB_MIDDLE_HUB_ID,
+			List.of(route1, route2)
+		);
+	}
+
+	private Delivery stubMovingDeliveryWithMultipleRoutes(UUID deliveryId) {
+		DeliveryId id = DeliveryId.of(deliveryId);
+		DeliveryRoute route1 = DeliveryRoute.reconstitute(
+			DeliveryRouteId.generate(), id, 0,
+			STUB_SOURCE_HUB_ID, STUB_MIDDLE_HUB_ID,
+			Distance.of(10000), Time.of(30), null, null, null, null,
+			RouteStatus.MOVING, STUB_ROUTE_MANAGER_ID
+		);
+		DeliveryRoute route2 = DeliveryRoute.create(id, 1, STUB_MIDDLE_HUB_ID, STUB_DESTINATION_HUB_ID, 8000, 25);
+		route2.assignManager(STUB_ROUTE_MANAGER_ID);
+		return Delivery.reconstitute(
+			id, UUID.randomUUID(), DeliveryStatus.FOR_HUB_MOVING,
+			STUB_SOURCE_HUB_ID, STUB_DESTINATION_HUB_ID,
+			Address.of("서울시 강남구 테헤란로 123", "101호"),
+			null,
+			UUID.randomUUID(), "slack-receiver", UUID.randomUUID(),
+			DeliveryManagerId.generate(), STUB_SOURCE_HUB_ID,
+			List.of(route1, route2)
+		);
+	}
+
+	private Delivery stubMovingDeliveryLastRoute(UUID deliveryId) {
+		DeliveryId id = DeliveryId.of(deliveryId);
+		DeliveryRoute route1 = DeliveryRoute.reconstitute(
+			DeliveryRouteId.generate(), id, 0,
+			STUB_SOURCE_HUB_ID, STUB_MIDDLE_HUB_ID,
+			Distance.of(10000), Time.of(30), null, null, null, null,
+			RouteStatus.ARRIVED, STUB_ROUTE_MANAGER_ID
+		);
+		DeliveryRoute route2 = DeliveryRoute.reconstitute(
+			DeliveryRouteId.generate(), id, 1,
+			STUB_MIDDLE_HUB_ID, STUB_DESTINATION_HUB_ID,
+			Distance.of(8000), Time.of(25), null, null, null, null,
+			RouteStatus.MOVING, STUB_ROUTE_MANAGER_ID
+		);
+		return Delivery.reconstitute(
+			id, UUID.randomUUID(), DeliveryStatus.FOR_HUB_MOVING,
+			STUB_SOURCE_HUB_ID, STUB_DESTINATION_HUB_ID,
+			Address.of("서울시 강남구 테헤란로 123", "101호"),
+			null,
+			UUID.randomUUID(), "slack-receiver", UUID.randomUUID(),
+			DeliveryManagerId.generate(), STUB_MIDDLE_HUB_ID,
+			List.of(route1, route2)
+		);
+	}
+
+	private Delivery stubDeliveryAtFinalHub(UUID deliveryId) {
+		DeliveryId id = DeliveryId.of(deliveryId);
+		DeliveryRoute hubRoute = DeliveryRoute.reconstitute(
+			DeliveryRouteId.generate(), id, 0,
+			STUB_SOURCE_HUB_ID, STUB_DESTINATION_HUB_ID,
+			Distance.of(10000), Time.of(30), null, null, null, null,
+			RouteStatus.ARRIVED, STUB_ROUTE_MANAGER_ID
+		);
+		DeliveryRoute companyRoute = DeliveryRoute.create(id, 1, STUB_DESTINATION_HUB_ID, UUID.randomUUID(), 5000, 20);
+		companyRoute.assignManager(STUB_ROUTE_MANAGER_ID);
+		return Delivery.reconstitute(
+			id, UUID.randomUUID(), DeliveryStatus.HUB_WAITING,
+			STUB_SOURCE_HUB_ID, STUB_DESTINATION_HUB_ID,
+			Address.of("서울시 강남구 테헤란로 123", "101호"),
+			null,
+			UUID.randomUUID(), "slack-receiver", UUID.randomUUID(),
+			DeliveryManagerId.generate(), STUB_DESTINATION_HUB_ID,
+			List.of(hubRoute, companyRoute)
 		);
 	}
 

--- a/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/DeliveryQueryServiceTest.java
+++ b/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/DeliveryQueryServiceTest.java
@@ -234,7 +234,7 @@ class DeliveryQueryServiceTest {
 			DeliveryListQuery query = stubQueryForRole(UserRole.COMPANY_MANAGER, managerId);
 
 			given(deliveryPermissionValidator.parseUserRole(UserRole.COMPANY_MANAGER.name())).willReturn(UserRole.COMPANY_MANAGER);
-			given(companyPort.getCompanyByManagerId(managerId)).willReturn(new CompanyResponse(companyId, UUID.randomUUID(), "테스트업체", "서울시 강남구 테헤란로 123", "101동 202호"));
+			given(companyPort.getCompanyByUserId(managerId)).willReturn(new CompanyResponse(companyId, UUID.randomUUID(), "테스트업체", "서울시 강남구 테헤란로 123", "101동 202호"));
 			given(deliveryQueryRepository.findDeliveries(any(DeliverySearchSpec.class))).willReturn(List.of(stubSummary()));
 
 			// when

--- a/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/DeliveryQueryServiceTest.java
+++ b/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/DeliveryQueryServiceTest.java
@@ -273,7 +273,7 @@ class DeliveryQueryServiceTest {
 			LocalDateTime endDate = LocalDateTime.now();
 			DeliveryListQuery query = new DeliveryListQuery(
 				UserRole.MASTER.name(), null, null,
-				null, DeliveryStatus.HUB_MOVING, sourceHubId, destinationHubId,
+				null, DeliveryStatus.FOR_HUB_MOVING, sourceHubId, destinationHubId,
 				null, null, null, null, null, null, null,
 				startDate, endDate, null, null, 10
 			);

--- a/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/facade/DeliveryCommandFacadeTest.java
+++ b/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/facade/DeliveryCommandFacadeTest.java
@@ -92,7 +92,7 @@ class DeliveryCommandFacadeTest {
 				.willReturn(new CompanyResponse(supplierCompanyId, supplierHubId, "공급업체", "서울시 송파구 올림픽로 300", "A동 1층"));
 			given(companyPort.getCompany(receiverCompanyId))
 				.willReturn(new CompanyResponse(receiverCompanyId, destinationHubId, "수령업체", "서울시 강남구 테헤란로 123", "101동 202호"));
-			given(hubPort.getHubRoute(supplierHubId, destinationHubId))
+			given(hubPort.getHubRoute(supplierHubId, destinationHubId, receiverCompanyId))
 				.willThrow(new DeliveryException(DeliveryErrorCode.HUB_NOT_FOUND));
 
 			// when

--- a/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/permission/DeliveryPermissionValidatorTest.java
+++ b/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/permission/DeliveryPermissionValidatorTest.java
@@ -243,7 +243,7 @@ class DeliveryPermissionValidatorTest {
 			// given
 			UUID userId = UUID.randomUUID();
 			DeliveryAccessContext context = stubContext();
-			given(companyPort.getCompanyByManagerId(userId))
+			given(companyPort.getCompanyByUserId(userId))
 				.willReturn(new CompanyResponse(RECEIVER_COMPANY_ID, UUID.randomUUID(), "테스트업체", "서울시 강남구 테헤란로 123", "101동 202호"));
 
 			// when & then (예외 없음)
@@ -257,7 +257,7 @@ class DeliveryPermissionValidatorTest {
 			UUID userId = UUID.randomUUID();
 			UUID otherCompanyId = UUID.randomUUID();
 			DeliveryAccessContext context = stubContext();
-			given(companyPort.getCompanyByManagerId(userId))
+			given(companyPort.getCompanyByUserId(userId))
 				.willReturn(new CompanyResponse(otherCompanyId, UUID.randomUUID(), "다른업체", "다른주소", "다른상세주소"));
 
 			// when


### PR DESCRIPTION
### 📌 관련 이슈
- close #115
- 
### 💡 작업 내용
- 배송 상태 변경(배송 시작, 목적지 허브 도착, 목적지 허브 받기, 업체 배송 시작, 배송 완료)
-

### 🔍 변경 이유
- 

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 배송 상태 전환 엔드포인트 5종 추가(시작, 허브 도착, 허브 입고, 업체 시작, 완료)
  * 상태 전환용 명령/응답 타입 및 성공 코드 추가
  * 배송 상태 변경 이벤트 생성 및 외부 전파(Kafka) 지원
  * 경로 기반 배송 진행 모델 도입 및 경로 상태(생성·이동·도착·완료) 명시화
* **변경**
  * 외부 클라이언트/포트 API 변경: 사용자 식별자 파라미터 및 hubRoute에 receiverCompanyId 추가
  * Feign 응답 래퍼명 변경(응답 타입 변경 반영)
  * 오류/성공 코드(열거형) 확장
* **테스트**
  * 신규 상태 전환 흐름 단위·통합 테스트 및 이벤트 검증 케이스 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->