### PR TITLE
fix: 허브 관리자 조회 수정

### DIFF
--- a/hub-service/src/main/java/com/firstlogistics/hubservice/hubManager/application/HubManagerQueryService.java
+++ b/hub-service/src/main/java/com/firstlogistics/hubservice/hubManager/application/HubManagerQueryService.java
@@ -28,7 +28,8 @@ public class HubManagerQueryService {
         Page<HubManager> hubManagers = repository.searchByCondition(query.toSpec(), pageable);
         return hubManagers.map(HubManagerResult::from);
     }
-    public UUID getHubIdByUserId(UUID userId){
-        return repository.findHubIdByUserId(UserId.of(userId)).id();
+    public HubManagerResult getHubManagerByUserId(UUID userId){
+        HubManager hubManager =  repository.findByUserId(UserId.of(userId));
+        return HubManagerResult.from(hubManager);
     }
 }

--- a/hub-service/src/main/java/com/firstlogistics/hubservice/hubManager/domain/repository/HubManagerQueryRepository.java
+++ b/hub-service/src/main/java/com/firstlogistics/hubservice/hubManager/domain/repository/HubManagerQueryRepository.java
@@ -1,7 +1,6 @@
 package com.firstlogistics.hubservice.hubManager.domain.repository;
 
 
-import com.firstlogistics.hubservice.hub.domain.vo.HubId;
 import com.firstlogistics.hubservice.hubManager.domain.entity.HubManager;
 import com.firstlogistics.hubservice.hubManager.domain.specification.HubManagerSearchSpec;
 import com.firstlogistics.hubservice.hubManager.domain.vo.HubManagerId;

--- a/hub-service/src/main/java/com/firstlogistics/hubservice/hubManager/domain/repository/HubManagerQueryRepository.java
+++ b/hub-service/src/main/java/com/firstlogistics/hubservice/hubManager/domain/repository/HubManagerQueryRepository.java
@@ -14,5 +14,5 @@ public interface HubManagerQueryRepository {
 
     Page<HubManager> searchByCondition(HubManagerSearchSpec spec, Pageable pageable);
 
-    HubId findHubIdByUserId(UserId userId);
+    HubManager findByUserId(UserId userId);
 }

--- a/hub-service/src/main/java/com/firstlogistics/hubservice/hubManager/infrastructure/persistence/jpa/HubManagerRepositoryImpl.java
+++ b/hub-service/src/main/java/com/firstlogistics/hubservice/hubManager/infrastructure/persistence/jpa/HubManagerRepositoryImpl.java
@@ -8,5 +8,4 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class HubManagerRepositoryImpl implements HubManagerRepository {
     private final HubManagerJpaRepository jpaRepository;
-    private final HubManagerMapper mapper;
 }

--- a/hub-service/src/main/java/com/firstlogistics/hubservice/hubManager/infrastructure/persistence/query/HubManagerQueryRepositoryImpl.java
+++ b/hub-service/src/main/java/com/firstlogistics/hubservice/hubManager/infrastructure/persistence/query/HubManagerQueryRepositoryImpl.java
@@ -79,9 +79,9 @@ public class HubManagerQueryRepositoryImpl implements HubManagerQueryRepository 
     }
 
     @Override
-    public HubId findHubIdByUserId(UserId userId) {
-        UUID result = queryFactory
-                .select(hubManager.hubId)
+    public HubManager findByUserId(UserId userId) {
+        HubManagerJpaEntity result = queryFactory
+                .select(hubManager)
                 .from(hubManager)
                 .where(
                         hubManager.userId.eq(userId.id()),
@@ -91,7 +91,7 @@ public class HubManagerQueryRepositoryImpl implements HubManagerQueryRepository 
         if (result == null)
             throw new HubManagerException(HubManagerErrorCode.HUB_MANAGER_NOT_FOUND);
 
-        return HubId.of(result);
+        return HubManagerMapper.toDomain(result);
     }
 
     private BooleanExpression notDeleted() {

--- a/hub-service/src/main/java/com/firstlogistics/hubservice/hubManager/infrastructure/persistence/query/HubManagerQueryRepositoryImpl.java
+++ b/hub-service/src/main/java/com/firstlogistics/hubservice/hubManager/infrastructure/persistence/query/HubManagerQueryRepositoryImpl.java
@@ -1,6 +1,5 @@
 package com.firstlogistics.hubservice.hubManager.infrastructure.persistence.query;
 
-import com.firstlogistics.hubservice.hub.domain.vo.HubId;
 import com.firstlogistics.hubservice.hubManager.domain.entity.HubManager;
 import com.firstlogistics.hubservice.hubManager.domain.exception.HubManagerErrorCode;
 import com.firstlogistics.hubservice.hubManager.domain.exception.HubManagerException;

--- a/hub-service/src/main/java/com/firstlogistics/hubservice/hubManager/presentation/HubManagerApiController.java
+++ b/hub-service/src/main/java/com/firstlogistics/hubservice/hubManager/presentation/HubManagerApiController.java
@@ -1,6 +1,7 @@
 package com.firstlogistics.hubservice.hubManager.presentation;
 
 import com.firstlogistics.hubservice.hubManager.application.HubManagerQueryService;
+import com.firstlogistics.hubservice.hubManager.domain.entity.HubManager;
 import com.firstlogistics.hubservice.hubManager.presentation.dto.request.SearchHubManagersRequest;
 import com.firstlogistics.hubservice.hubManager.presentation.dto.response.HubManagerPageResponse;
 import com.firstlogistics.hubservice.hubManager.presentation.dto.response.HubManagerResponse;
@@ -16,7 +17,7 @@ import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/hubs/hub-managers")
+@RequestMapping("/api/v1/hub-managers")
 public class HubManagerApiController {
     private final HubManagerQueryService queryService;
 
@@ -35,9 +36,9 @@ public class HubManagerApiController {
                 .body(ApiResponse.success(HubManagerSuccessCode.HUB_MANAGER_LIST_RETRIEVED,response));
     }
 
-    @GetMapping("/users/{id}/hub")
-    public ResponseEntity<ApiResponse<UUID>> getHubIdByUserId(@PathVariable UUID id){
-        UUID hubId = queryService.getHubIdByUserId(id);
+    @GetMapping("/users/{id}")
+    public ResponseEntity<ApiResponse<HubManagerResponse>> getHubIdByUserId(@PathVariable UUID id){
+        HubManagerResponse hubId = HubManagerResponse.from(queryService.getHubManagerByUserId(id));
         return ResponseEntity.status(HubManagerSuccessCode.HUB_MANAGER_HUB_ID_RETRIEVED.getStatus())
                 .body(ApiResponse.success(HubManagerSuccessCode.HUB_MANAGER_HUB_ID_RETRIEVED,hubId));
     }

--- a/hub-service/src/main/java/com/firstlogistics/hubservice/hubManager/presentation/HubManagerApiController.java
+++ b/hub-service/src/main/java/com/firstlogistics/hubservice/hubManager/presentation/HubManagerApiController.java
@@ -1,7 +1,6 @@
 package com.firstlogistics.hubservice.hubManager.presentation;
 
 import com.firstlogistics.hubservice.hubManager.application.HubManagerQueryService;
-import com.firstlogistics.hubservice.hubManager.domain.entity.HubManager;
 import com.firstlogistics.hubservice.hubManager.presentation.dto.request.SearchHubManagersRequest;
 import com.firstlogistics.hubservice.hubManager.presentation.dto.response.HubManagerPageResponse;
 import com.firstlogistics.hubservice.hubManager.presentation.dto.response.HubManagerResponse;
@@ -37,10 +36,10 @@ public class HubManagerApiController {
     }
 
     @GetMapping("/users/{id}")
-    public ResponseEntity<ApiResponse<HubManagerResponse>> getHubIdByUserId(@PathVariable UUID id){
-        HubManagerResponse hubId = HubManagerResponse.from(queryService.getHubManagerByUserId(id));
+    public ResponseEntity<ApiResponse<HubManagerResponse>> getHubManagerByUserId(@PathVariable UUID id){
+        HubManagerResponse response = HubManagerResponse.from(queryService.getHubManagerByUserId(id));
         return ResponseEntity.status(HubManagerSuccessCode.HUB_MANAGER_RETRIEVED.getStatus())
-                .body(ApiResponse.success(HubManagerSuccessCode.HUB_MANAGER_RETRIEVED,hubId));
+                .body(ApiResponse.success(HubManagerSuccessCode.HUB_MANAGER_RETRIEVED,response));
     }
 
 }

--- a/hub-service/src/main/java/com/firstlogistics/hubservice/hubManager/presentation/HubManagerApiController.java
+++ b/hub-service/src/main/java/com/firstlogistics/hubservice/hubManager/presentation/HubManagerApiController.java
@@ -39,8 +39,8 @@ public class HubManagerApiController {
     @GetMapping("/users/{id}")
     public ResponseEntity<ApiResponse<HubManagerResponse>> getHubIdByUserId(@PathVariable UUID id){
         HubManagerResponse hubId = HubManagerResponse.from(queryService.getHubManagerByUserId(id));
-        return ResponseEntity.status(HubManagerSuccessCode.HUB_MANAGER_HUB_ID_RETRIEVED.getStatus())
-                .body(ApiResponse.success(HubManagerSuccessCode.HUB_MANAGER_HUB_ID_RETRIEVED,hubId));
+        return ResponseEntity.status(HubManagerSuccessCode.HUB_MANAGER_RETRIEVED.getStatus())
+                .body(ApiResponse.success(HubManagerSuccessCode.HUB_MANAGER_RETRIEVED,hubId));
     }
 
 }

--- a/hub-service/src/main/java/com/firstlogistics/hubservice/hubManager/presentation/HubManagerSuccessCode.java
+++ b/hub-service/src/main/java/com/firstlogistics/hubservice/hubManager/presentation/HubManagerSuccessCode.java
@@ -9,9 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum HubManagerSuccessCode implements SuccessCode {
     HUB_MANAGER_RETRIEVED(HttpStatus.OK, "HBM_S002", "허브 관리자 조회에 성공했습니다."),
-    HUB_MANAGER_LIST_RETRIEVED(HttpStatus.OK, "HBM_S003", "허브 관리자 목록 조회에 성공했습니다."),
-    HUB_MANAGER_HUB_ID_RETRIEVED(HttpStatus.OK, "HBM_S004", "허브 관리자가 소속된 허브 아이디 조회에 성공했습니다.");
-
+    HUB_MANAGER_LIST_RETRIEVED(HttpStatus.OK, "HBM_S003", "허브 관리자 목록 조회에 성공했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/hub-service/src/test/java/com/firstlogistics/hubservice/hubManager/application/HubManagerQueryServiceTest.java
+++ b/hub-service/src/test/java/com/firstlogistics/hubservice/hubManager/application/HubManagerQueryServiceTest.java
@@ -93,15 +93,16 @@ class HubManagerQueryServiceTest {
     @Test
     @DisplayName("유저 ID로 소속 허브 ID를 조회한다")
     void getHubIdByUserId() {
+        UUID hubManagerId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
         UUID hubId = UUID.randomUUID();
+        HubManager hubManager = createHubManager(hubManagerId, userId, hubId);
+        when(repository.findByUserId(UserId.of(userId))).thenReturn(hubManager);
 
-        when(repository.findHubIdByUserId(UserId.of(userId))).thenReturn(HubId.of(hubId));
+        HubManagerResult result = service.getHubManagerByUserId(userId);
 
-        UUID result = service.getHubIdByUserId(userId);
-
-        assertThat(result).isEqualTo(hubId);
-        verify(repository).findHubIdByUserId(UserId.of(userId));
+        assertThat(result.userId()).isEqualTo(userId);
+        verify(repository).findByUserId(UserId.of(userId));
     }
 
     private HubManager createHubManager(UUID hubManagerId, UUID userId, UUID hubId) {

--- a/hub-service/src/test/java/com/firstlogistics/hubservice/hubManager/application/HubManagerQueryServiceTest.java
+++ b/hub-service/src/test/java/com/firstlogistics/hubservice/hubManager/application/HubManagerQueryServiceTest.java
@@ -91,7 +91,7 @@ class HubManagerQueryServiceTest {
     }
 
     @Test
-    @DisplayName("유저 ID로 소속 허브 ID를 조회한다")
+    @DisplayName("유저 ID로 허브 매니저 정보를 조회한다")
     void getHubIdByUserId() {
         UUID hubManagerId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
@@ -102,6 +102,8 @@ class HubManagerQueryServiceTest {
         HubManagerResult result = service.getHubManagerByUserId(userId);
 
         assertThat(result.userId()).isEqualTo(userId);
+        assertThat(result.hubId()).isEqualTo(hubId);
+        assertThat(result.hubManagerId()).isEqualTo(hubManagerId);
         verify(repository).findByUserId(UserId.of(userId));
     }
 


### PR DESCRIPTION
### 📌 관련 이슈
- close #138 
- 
### 💡 작업 내용
- 
-

### 🔍 변경 이유
- 응답 형식 통일
- controller url 수정
- mapper 빈주입 오류 수정

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **주요 변경사항**
  * 허브 관리자 API 엔드포인트 경로 단순화: `/api/v1/hubs/hub-managers/users/{id}/hub` → `/api/v1/hub-managers/users/{id}`
  * 사용자별 허브 관리자 조회 응답 확장: 기존 허브 ID만 반환하던 것에서 완전한 허브 관리자 정보로 변경

* **기타**
  * 관련 성공 코드 메시지 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->