### PR TITLE
Feat 배송 취소

### DIFF
--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/DeliveryCommandService.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/DeliveryCommandService.java
@@ -276,14 +276,7 @@ public class DeliveryCommandService {
 		return ChangeDeliveryStatusResult.from(savedDelivery);
 	}
 
-	public ChangeDeliveryStatusResult cancelDelivery(ChangeDeliveryStatusCommand command) {
-		Delivery delivery = deliveryRepository.findById(DeliveryId.of(command.deliveryId()))
-			.orElseThrow(() -> new DeliveryException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
-
-		DeliveryAccessContext accessContext = DeliveryAccessContext.from(delivery);
-		deliveryPermissionValidator.validate(accessContext, command.role(), command.userId(),
-			Set.of(UserRole.MASTER, UserRole.HUB_MANAGER));
-
+	public ChangeDeliveryStatusResult cancelDelivery(Delivery delivery) {
 		delivery.cancelDelivery();
 		Delivery savedDelivery = deliveryRepository.save(delivery);
 
@@ -293,15 +286,8 @@ public class DeliveryCommandService {
 		return ChangeDeliveryStatusResult.from(savedDelivery);
 	}
 
-	public void cancelByOrder(UUID orderId) {
-		Delivery delivery = deliveryRepository.findByOrderId(orderId)
-			.orElseThrow(() -> new DeliveryException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
-
-		if (delivery.getStatus() == DeliveryStatus.CANCELLED) {
-			return;
-		}
-
-		delivery.cancelByOrder();
+	public void cancelDeliveryBySystem(Delivery delivery) {
+		delivery.cancelBySystem();
 		Delivery savedDelivery = deliveryRepository.save(delivery);
 
 		deliveryEventPublisher.publishDeliveryStatusChanged(

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/DeliveryCommandService.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/DeliveryCommandService.java
@@ -12,6 +12,7 @@ import com.firstlogistics.deliverservice.application.publisher.DeliveryEventPubl
 import com.firstlogistics.deliverservice.domain.entity.Delivery;
 import com.firstlogistics.deliverservice.domain.entity.DeliveryRoute;
 import com.firstlogistics.deliverservice.domain.entity.DeliveryManager;
+import com.firstlogistics.deliverservice.domain.enums.DeliveryStatus;
 import com.firstlogistics.deliverservice.domain.enums.UserRole;
 import com.firstlogistics.deliverservice.domain.event.DeliveryCreatedEvent;
 import com.firstlogistics.deliverservice.domain.event.DeliveryStatusChangedEvent;
@@ -273,6 +274,38 @@ public class DeliveryCommandService {
 			DeliveryStatusChangedEvent.create(savedDelivery));
 
 		return ChangeDeliveryStatusResult.from(savedDelivery);
+	}
+
+	public ChangeDeliveryStatusResult cancelDelivery(ChangeDeliveryStatusCommand command) {
+		Delivery delivery = deliveryRepository.findById(DeliveryId.of(command.deliveryId()))
+			.orElseThrow(() -> new DeliveryException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
+
+		DeliveryAccessContext accessContext = DeliveryAccessContext.from(delivery);
+		deliveryPermissionValidator.validate(accessContext, command.role(), command.userId(),
+			Set.of(UserRole.MASTER, UserRole.HUB_MANAGER));
+
+		delivery.cancelDelivery();
+		Delivery savedDelivery = deliveryRepository.save(delivery);
+
+		deliveryEventPublisher.publishDeliveryStatusChanged(
+			DeliveryStatusChangedEvent.create(savedDelivery));
+
+		return ChangeDeliveryStatusResult.from(savedDelivery);
+	}
+
+	public void cancelByOrder(UUID orderId) {
+		Delivery delivery = deliveryRepository.findByOrderId(orderId)
+			.orElseThrow(() -> new DeliveryException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
+
+		if (delivery.getStatus() == DeliveryStatus.CANCELLED) {
+			return;
+		}
+
+		delivery.cancelByOrder();
+		Delivery savedDelivery = deliveryRepository.save(delivery);
+
+		deliveryEventPublisher.publishDeliveryStatusChanged(
+			DeliveryStatusChangedEvent.create(savedDelivery));
 	}
 
 	private DeliveryCreatedEvent buildDeliveryCreatedEvent(

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/DeliveryCommandService.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/DeliveryCommandService.java
@@ -346,6 +346,8 @@ public class DeliveryCommandService {
 			delivery.getCurrentHubId(),
 			receiver.name(),
 			delivery.getReceiverSlackId(),
+			receiver.email(),
+			receiver.phone(),
 			command.receiverRoadAddress(),
 			command.receiverDetailAddress(),
 			deliveryRoutes,

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/DeliveryCommandService.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/DeliveryCommandService.java
@@ -343,6 +343,7 @@ public class DeliveryCommandService {
 
 		DeliveryCreatedEvent.DeliveryInfo deliveryInfo = DeliveryCreatedEvent.DeliveryInfo.of(
 			delivery.getId().id(),
+			delivery.getCurrentHubId(),
 			receiver.name(),
 			delivery.getReceiverSlackId(),
 			command.receiverRoadAddress(),

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/facade/DeliveryCommandFacade.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/facade/DeliveryCommandFacade.java
@@ -39,7 +39,16 @@ public class DeliveryCommandFacade {
     private final HubPort hubPort;
     private final DistributedLockPort distributedLockPort;
 
-    public CreateDeliveryResult createDelivery(CreateDeliveryCommand command) {
+    public CreateDeliveryResult createDelivery(CreateDeliveryCommand command, String role, UUID userId) {
+        deliveryPermissionValidator.validateRole(role, Set.of(UserRole.MASTER));
+        return executeCreateDelivery(command);
+    }
+
+    public CreateDeliveryResult createDeliveryBySystem(CreateDeliveryCommand command) {
+        return executeCreateDelivery(command);
+    }
+
+    private CreateDeliveryResult executeCreateDelivery(CreateDeliveryCommand command) {
         CompanyResponse supplierCompany = companyPort.getCompany(command.supplierCompanyId());
         CompanyResponse receiverCompany = companyPort.getCompany(command.receiverCompanyId());
 

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/facade/DeliveryCommandFacade.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/facade/DeliveryCommandFacade.java
@@ -1,8 +1,12 @@
 package com.firstlogistics.deliverservice.application.facade;
 
 import com.firstlogistics.deliverservice.application.DeliveryCommandService;
+import com.firstlogistics.deliverservice.application.dto.command.ChangeDeliveryStatusCommand;
 import com.firstlogistics.deliverservice.application.dto.command.CreateDeliveryCommand;
+import com.firstlogistics.deliverservice.application.dto.result.ChangeDeliveryStatusResult;
 import com.firstlogistics.deliverservice.application.dto.result.CreateDeliveryResult;
+import com.firstlogistics.deliverservice.application.permission.DeliveryAccessContext;
+import com.firstlogistics.deliverservice.application.permission.DeliveryPermissionValidator;
 import com.firstlogistics.deliverservice.application.port.CompanyPort;
 import com.firstlogistics.deliverservice.application.port.HubPort;
 import com.firstlogistics.deliverservice.application.port.dto.CompanyResponse;
@@ -10,10 +14,18 @@ import com.firstlogistics.deliverservice.application.port.dto.HubRouteResponse;
 import com.firstlogistics.deliverservice.application.port.dto.HubRouteStepResponse;
 import com.firstlogistics.deliverservice.application.port.DistributedLockPort;
 import com.firstlogistics.deliverservice.application.support.DeliveryLockKeyGenerator;
+import com.firstlogistics.deliverservice.domain.entity.Delivery;
+import com.firstlogistics.deliverservice.domain.enums.DeliveryStatus;
+import com.firstlogistics.deliverservice.domain.enums.UserRole;
+import com.firstlogistics.deliverservice.domain.exception.DeliveryErrorCode;
+import com.firstlogistics.deliverservice.domain.exception.DeliveryException;
+import com.firstlogistics.deliverservice.domain.repository.DeliveryRepository;
+import com.firstlogistics.deliverservice.domain.vo.DeliveryId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 @Component
@@ -21,6 +33,8 @@ import java.util.UUID;
 public class DeliveryCommandFacade {
 
     private final DeliveryCommandService deliveryCommandService;
+    private final DeliveryRepository deliveryRepository;
+    private final DeliveryPermissionValidator deliveryPermissionValidator;
     private final CompanyPort companyPort;
     private final HubPort hubPort;
     private final DistributedLockPort distributedLockPort;
@@ -41,6 +55,28 @@ public class DeliveryCommandFacade {
                         lockKeys,
                         () -> deliveryCommandService.createDelivery(command, supplierCompany, receiverCompany, hubRoute)
                 );
+    }
+
+    public ChangeDeliveryStatusResult cancelDelivery(ChangeDeliveryStatusCommand command) {
+        Delivery delivery = deliveryRepository.findById(DeliveryId.of(command.deliveryId()))
+            .orElseThrow(() -> new DeliveryException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
+
+        DeliveryAccessContext accessContext = DeliveryAccessContext.from(delivery);
+        deliveryPermissionValidator.validate(accessContext, command.role(), command.userId(),
+            Set.of(UserRole.MASTER, UserRole.HUB_MANAGER));
+
+        return deliveryCommandService.cancelDelivery(delivery);
+    }
+
+    public void cancelDeliveryBySystem(UUID orderId) {
+        Delivery delivery = deliveryRepository.findByOrderId(orderId)
+            .orElseThrow(() -> new DeliveryException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
+
+        if (delivery.getStatus() == DeliveryStatus.CANCELLED) {
+            return;
+        }
+
+        deliveryCommandService.cancelDeliveryBySystem(delivery);
     }
 
     private List<String> generateLockKeys(HubRouteResponse hubRoute) {

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/permission/DeliveryPermissionValidator.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/permission/DeliveryPermissionValidator.java
@@ -30,6 +30,13 @@ public class DeliveryPermissionValidator {
 		}
 	}
 
+	public void validateRole(String role, Set<UserRole> allowedRoles) {
+		UserRole userRole = parseUserRole(role);
+		if (!allowedRoles.contains(userRole)) {
+			throw new DeliveryException(DeliveryErrorCode.DELIVERY_ACCESS_DENIED);
+		}
+	}
+
 	public void validate(DeliveryAccessContext context, String role, UUID userId, Set<UserRole> allowedRoles) {
 		UserRole userRole = parseUserRole(role);
 		if (!allowedRoles.contains(userRole)) {

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/permission/DeliveryPermissionValidator.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/application/permission/DeliveryPermissionValidator.java
@@ -30,18 +30,16 @@ public class DeliveryPermissionValidator {
 		}
 	}
 
-	public void validateRole(String role, Set<UserRole> allowedRoles) {
+	public UserRole validateRole(String role, Set<UserRole> allowedRoles) {
 		UserRole userRole = parseUserRole(role);
 		if (!allowedRoles.contains(userRole)) {
 			throw new DeliveryException(DeliveryErrorCode.DELIVERY_ACCESS_DENIED);
 		}
+		return userRole;
 	}
 
 	public void validate(DeliveryAccessContext context, String role, UUID userId, Set<UserRole> allowedRoles) {
-		UserRole userRole = parseUserRole(role);
-		if (!allowedRoles.contains(userRole)) {
-			throw new DeliveryException(DeliveryErrorCode.DELIVERY_ACCESS_DENIED);
-		}
+		UserRole userRole = validateRole(role, allowedRoles);
 		RolePermissionStrategy strategy = strategies.get(userRole);
 		if (strategy == null) {
 			throw new DeliveryException(DeliveryErrorCode.INVALID_ROLE_SCOPE);

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/entity/Delivery.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/entity/Delivery.java
@@ -144,6 +144,10 @@ public class Delivery {
 	}
 
 	public void cancelBySystem() {
+		if (this.status == DeliveryStatus.CANCELLED) {
+			return;
+		}
+		validateStatusTransition(Set.of(DeliveryStatus.CREATED));
 		this.status = DeliveryStatus.CANCELLED;
 	}
 

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/entity/Delivery.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/entity/Delivery.java
@@ -147,6 +147,11 @@ public class Delivery {
 		this.status = DeliveryStatus.CANCELLED;
 	}
 
+	public void cancelDelivery() {
+		validateStatusTransition(Set.of(DeliveryStatus.CREATED));
+		this.status = DeliveryStatus.CANCELLED;
+	}
+
 	public void reassignReceiver(UUID receiverId, String receiverSlackId) {
 		validateBeforeDelivery();
 		if (receiverId != null) {

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/entity/Delivery.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/entity/Delivery.java
@@ -143,7 +143,7 @@ public class Delivery {
 		this.status = DeliveryStatus.COMPLETED;
 	}
 
-	public void cancelByOrder() {
+	public void cancelBySystem() {
 		this.status = DeliveryStatus.CANCELLED;
 	}
 

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/enums/DeliveryStatus.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/enums/DeliveryStatus.java
@@ -7,8 +7,7 @@ public enum DeliveryStatus {
 	HUB_ARRIVED("허브 도착"),
 	FOR_COMPANY_MOVING("업체로 이동중"),
 	COMPLETED("배송 완료"),
-	CANCELLED("배송 취소"),
-	CANCEL_REQUESTED("배송 취소 대기");
+	CANCELLED("배송 취소");
 
 	private final String description;
 

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/event/DeliveryCreatedEvent.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/event/DeliveryCreatedEvent.java
@@ -39,6 +39,7 @@ public record DeliveryCreatedEvent(
 
 	public record DeliveryInfo(
 		UUID deliveryId,
+		UUID currentHubId,
 		String receiverName,
 		String receiverSlackId,
 		String receiverRoadAddress,
@@ -49,12 +50,12 @@ public record DeliveryCreatedEvent(
 		String companyDeliveryManagerPhone,
 		String companyDeliveryManagerEmail
 	) {
-		public static DeliveryInfo of(UUID deliveryId, String receiverName, String receiverSlackId,
+		public static DeliveryInfo of(UUID deliveryId, UUID currentHubId, String receiverName, String receiverSlackId,
 				String receiverRoadAddress, String receiverDetailAddress,
 				List<DeliveryRouteInfo> deliveryRoutes,
 				String companyDeliveryManagerSlackId, String companyDeliveryManagerName,
 				String companyDeliveryManagerPhone, String companyDeliveryManagerEmail) {
-			return new DeliveryInfo(deliveryId, receiverName, receiverSlackId,
+			return new DeliveryInfo(deliveryId, currentHubId, receiverName, receiverSlackId,
 				receiverRoadAddress, receiverDetailAddress, deliveryRoutes,
 				companyDeliveryManagerSlackId, companyDeliveryManagerName,
 				companyDeliveryManagerPhone, companyDeliveryManagerEmail);

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/event/DeliveryCreatedEvent.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/event/DeliveryCreatedEvent.java
@@ -42,6 +42,8 @@ public record DeliveryCreatedEvent(
 		UUID currentHubId,
 		String receiverName,
 		String receiverSlackId,
+		String receiverEmail,
+		String receiverPhone,
 		String receiverRoadAddress,
 		String receiverDetailAddress,
 		List<DeliveryRouteInfo> deliveryRoutes,
@@ -51,11 +53,13 @@ public record DeliveryCreatedEvent(
 		String companyDeliveryManagerEmail
 	) {
 		public static DeliveryInfo of(UUID deliveryId, UUID currentHubId, String receiverName, String receiverSlackId,
+				String receiverEmail, String receiverPhone,
 				String receiverRoadAddress, String receiverDetailAddress,
 				List<DeliveryRouteInfo> deliveryRoutes,
 				String companyDeliveryManagerSlackId, String companyDeliveryManagerName,
 				String companyDeliveryManagerPhone, String companyDeliveryManagerEmail) {
 			return new DeliveryInfo(deliveryId, currentHubId, receiverName, receiverSlackId,
+				receiverEmail, receiverPhone,
 				receiverRoadAddress, receiverDetailAddress, deliveryRoutes,
 				companyDeliveryManagerSlackId, companyDeliveryManagerName,
 				companyDeliveryManagerPhone, companyDeliveryManagerEmail);

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/event/OrderCancelledEvent.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/event/OrderCancelledEvent.java
@@ -1,0 +1,15 @@
+package com.firstlogistics.deliverservice.domain.event;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.UUID;
+
+/**
+ * 주문 취소 이벤트 (order.cancelled 토픽)
+ * Jackson 역직렬화용 — create() 정적 팩토리 없음
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record OrderCancelledEvent(
+	UUID orderId
+) {
+}

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/repository/DeliveryRepository.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/domain/repository/DeliveryRepository.java
@@ -12,5 +12,7 @@ public interface DeliveryRepository {
 
 	Optional<Delivery> findById(DeliveryId deliveryId);
 
+	Optional<Delivery> findByOrderId(UUID orderId);
+
 	Delivery save(Delivery delivery);
 }

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/messaging/config/OrderAcceptedConsumerConfig.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/messaging/config/OrderAcceptedConsumerConfig.java
@@ -28,7 +28,7 @@ public class OrderAcceptedConsumerConfig {
 	@Bean
 	public ConsumerFactory<String, OrderAcceptedEvent> orderAcceptedConsumerFactory() {
 		JsonDeserializer<OrderAcceptedEvent> deserializer = new JsonDeserializer<>(OrderAcceptedEvent.class, objectMapper);
-		deserializer.addTrustedPackages("*");
+		deserializer.addTrustedPackages("com.firstlogistics.deliverservice.domain.event");
 		deserializer.setUseTypeHeaders(false);
 		return new DefaultKafkaConsumerFactory<>(kafkaConsumerConfig.commonConsumerProps(), new StringDeserializer(), deserializer);
 	}

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/messaging/config/OrderCancelledConsumerConfig.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/messaging/config/OrderCancelledConsumerConfig.java
@@ -26,7 +26,7 @@ public class OrderCancelledConsumerConfig {
 	@Bean
 	public ConsumerFactory<String, OrderCancelledEvent> orderCancelledConsumerFactory() {
 		JsonDeserializer<OrderCancelledEvent> deserializer = new JsonDeserializer<>(OrderCancelledEvent.class, objectMapper);
-		deserializer.addTrustedPackages("*");
+		deserializer.addTrustedPackages("com.firstlogistics.deliverservice.domain.event");
 		deserializer.setUseTypeHeaders(false);
 		return new DefaultKafkaConsumerFactory<>(kafkaConsumerConfig.commonConsumerProps(), new StringDeserializer(), deserializer);
 	}

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/messaging/config/OrderCancelledConsumerConfig.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/messaging/config/OrderCancelledConsumerConfig.java
@@ -1,0 +1,57 @@
+package com.firstlogistics.deliverservice.infrastructure.messaging.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.firstlogistics.deliverservice.domain.event.OrderCancelledEvent;
+import com.firstlogistics.deliverservice.domain.exception.DeliveryException;
+import com.firstlogistics.deliverservice.infrastructure.messaging.producer.DeliveryEventKafkaProducer;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.util.backoff.FixedBackOff;
+
+@Configuration
+@RequiredArgsConstructor
+public class OrderCancelledConsumerConfig {
+
+	private final KafkaConsumerConfig kafkaConsumerConfig;
+	private final ObjectMapper objectMapper;
+
+	@Bean
+	public ConsumerFactory<String, OrderCancelledEvent> orderCancelledConsumerFactory() {
+		JsonDeserializer<OrderCancelledEvent> deserializer = new JsonDeserializer<>(OrderCancelledEvent.class, objectMapper);
+		deserializer.addTrustedPackages("*");
+		deserializer.setUseTypeHeaders(false);
+		return new DefaultKafkaConsumerFactory<>(kafkaConsumerConfig.commonConsumerProps(), new StringDeserializer(), deserializer);
+	}
+
+	@Bean
+	public DefaultErrorHandler orderCancelledErrorHandler(DeliveryEventKafkaProducer deliveryEventKafkaProducer) {
+		DefaultErrorHandler errorHandler = new DefaultErrorHandler(
+			(record, exception) -> {
+				deliveryEventKafkaProducer.handleOrderCancelledDlt(String.valueOf(record.key()), record.value());
+			},
+			new FixedBackOff(1000L, 3L)
+		);
+		errorHandler.addNotRetryableExceptions(DeliveryException.class);
+		return errorHandler;
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, OrderCancelledEvent> orderCancelledListenerContainerFactory(
+		DefaultErrorHandler orderCancelledErrorHandler
+	) {
+		ConcurrentKafkaListenerContainerFactory<String, OrderCancelledEvent> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+		factory.setConsumerFactory(orderCancelledConsumerFactory());
+		factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
+		factory.setCommonErrorHandler(orderCancelledErrorHandler);
+		return factory;
+	}
+}

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/messaging/consumer/OrderEventKafkaConsumer.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/messaging/consumer/OrderEventKafkaConsumer.java
@@ -46,7 +46,8 @@ public class OrderEventKafkaConsumer {
 	public void handleOrderCancelled(OrderCancelledEvent event, Acknowledgment ack) {
 		log.info("order.cancelled 이벤트 수신 - orderId: {}", event.orderId());
 
-		deliveryCommandFacade.cancelDeliveryBySystem(event.orderId());
+		// 배송 취소(배송 출발 전 취소) 추후 고도화
+//		deliveryCommandFacade.cancelDeliveryBySystem(event.orderId());
 
 		ack.acknowledge();
 	}

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/messaging/consumer/OrderEventKafkaConsumer.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/messaging/consumer/OrderEventKafkaConsumer.java
@@ -1,9 +1,11 @@
 package com.firstlogistics.deliverservice.infrastructure.messaging.consumer;
 
+import com.firstlogistics.deliverservice.application.DeliveryCommandService;
 import com.firstlogistics.deliverservice.application.DeliveryQueryService;
 import com.firstlogistics.deliverservice.application.dto.command.CreateDeliveryCommand;
 import com.firstlogistics.deliverservice.application.facade.DeliveryCommandFacade;
 import com.firstlogistics.deliverservice.domain.event.OrderAcceptedEvent;
+import com.firstlogistics.deliverservice.domain.event.OrderCancelledEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -15,6 +17,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class OrderEventKafkaConsumer {
 
+	private final DeliveryCommandService deliveryCommandService;
 	private final DeliveryQueryService deliveryQueryService;
 	private final DeliveryCommandFacade deliveryCommandFacade;
 
@@ -33,6 +36,19 @@ public class OrderEventKafkaConsumer {
 		}
 
 		deliveryCommandFacade.createDelivery(CreateDeliveryCommand.from(event));
+
+		ack.acknowledge();
+	}
+
+	@KafkaListener(
+		topics = "order.cancelled",
+		groupId = "delivery-service",
+		containerFactory = "orderCancelledListenerContainerFactory"
+	)
+	public void handleOrderCancelled(OrderCancelledEvent event, Acknowledgment ack) {
+		log.info("order.cancelled 이벤트 수신 - orderId: {}", event.orderId());
+
+		deliveryCommandService.cancelByOrder(event.orderId());
 
 		ack.acknowledge();
 	}

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/messaging/consumer/OrderEventKafkaConsumer.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/messaging/consumer/OrderEventKafkaConsumer.java
@@ -1,6 +1,5 @@
 package com.firstlogistics.deliverservice.infrastructure.messaging.consumer;
 
-import com.firstlogistics.deliverservice.application.DeliveryCommandService;
 import com.firstlogistics.deliverservice.application.DeliveryQueryService;
 import com.firstlogistics.deliverservice.application.dto.command.CreateDeliveryCommand;
 import com.firstlogistics.deliverservice.application.facade.DeliveryCommandFacade;
@@ -17,7 +16,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class OrderEventKafkaConsumer {
 
-	private final DeliveryCommandService deliveryCommandService;
 	private final DeliveryQueryService deliveryQueryService;
 	private final DeliveryCommandFacade deliveryCommandFacade;
 
@@ -48,7 +46,7 @@ public class OrderEventKafkaConsumer {
 	public void handleOrderCancelled(OrderCancelledEvent event, Acknowledgment ack) {
 		log.info("order.cancelled 이벤트 수신 - orderId: {}", event.orderId());
 
-		deliveryCommandService.cancelByOrder(event.orderId());
+		deliveryCommandFacade.cancelDeliveryBySystem(event.orderId());
 
 		ack.acknowledge();
 	}

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/messaging/consumer/OrderEventKafkaConsumer.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/messaging/consumer/OrderEventKafkaConsumer.java
@@ -33,7 +33,7 @@ public class OrderEventKafkaConsumer {
 			return;
 		}
 
-		deliveryCommandFacade.createDelivery(CreateDeliveryCommand.from(event));
+		deliveryCommandFacade.createDeliveryBySystem(CreateDeliveryCommand.from(event));
 
 		ack.acknowledge();
 	}

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/messaging/producer/DeliveryEventKafkaProducer.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/messaging/producer/DeliveryEventKafkaProducer.java
@@ -21,6 +21,7 @@ public class DeliveryEventKafkaProducer {
 	private static final String TOPIC_CREATION_FAILED = "delivery.creation.failed";
 	private static final String TOPIC_STATUS_CHANGED = "delivery.status.changed";
 	private static final String TOPIC_ORDER_ACCEPTED_DLT = "order.accepted.DLT";
+	private static final String TOPIC_ORDER_CANCELLED_DLT = "order.cancelled.DLT";
 
 	private final KafkaTemplate<String, Object> deliveryKafkaTemplate;
 
@@ -50,5 +51,10 @@ public class DeliveryEventKafkaProducer {
 	public void handleOrderAcceptedDlt(String key, Object value) {
 		deliveryKafkaTemplate.send(TOPIC_ORDER_ACCEPTED_DLT, key, value);
 		log.warn("DLT 적재 - topic: {}, key: {}", TOPIC_ORDER_ACCEPTED_DLT, key);
+	}
+
+	public void handleOrderCancelledDlt(String key, Object value) {
+		deliveryKafkaTemplate.send(TOPIC_ORDER_CANCELLED_DLT, key, value);
+		log.warn("DLT 적재 - topic: {}, key: {}", TOPIC_ORDER_CANCELLED_DLT, key);
 	}
 }

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/persistence/jpa/DeliveryJpaRepository.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/persistence/jpa/DeliveryJpaRepository.java
@@ -2,9 +2,12 @@ package com.firstlogistics.deliverservice.infrastructure.persistence.jpa;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface DeliveryJpaRepository extends JpaRepository<DeliveryJpaEntity, UUID> {
 
 	boolean existsByOrderId(UUID orderId);
+
+	Optional<DeliveryJpaEntity> findByOrderId(UUID orderId);
 }

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/persistence/jpa/DeliveryRepositoryImpl.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/infrastructure/persistence/jpa/DeliveryRepositoryImpl.java
@@ -28,6 +28,12 @@ public class DeliveryRepositoryImpl implements DeliveryRepository {
 	}
 
 	@Override
+	public Optional<Delivery> findByOrderId(UUID orderId) {
+		return deliveryJpaRepository.findByOrderId(orderId)
+			.map(deliveryMapper::toDomain);
+	}
+
+	@Override
 	public Delivery save(Delivery delivery) {
 		DeliveryJpaEntity jpaEntity = deliveryMapper.toJpaEntity(delivery);
 		DeliveryJpaEntity savedEntity = deliveryJpaRepository.save(jpaEntity);

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/presentation/DeliveryController.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/presentation/DeliveryController.java
@@ -119,6 +119,17 @@ public class DeliveryController {
 		));
 	}
 
+	@PostMapping("/{deliveryId}/cancel")
+	public ResponseEntity<ApiResponse<ChangeDeliveryStatusResponse>> cancelDelivery(
+		@PathVariable UUID deliveryId,
+		@RequestHeader("X-User-Id") UUID userId,
+		@RequestHeader("X-User-Role") String role
+	) {
+		return ResponseEntity.ok(ApiResponse.success(DeliverySuccessCode.DELIVERY_CANCELLED,
+				ChangeDeliveryStatusResponse.from(deliveryCommandService.cancelDelivery(ChangeDeliveryStatusCommand.of(deliveryId, role, userId)))
+		));
+	}
+
 	@GetMapping("/{deliveryId}")
 	public ResponseEntity<ApiResponse<DeliveryDetailResponse>> getDelivery(
 		@PathVariable UUID deliveryId,

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/presentation/DeliveryController.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/presentation/DeliveryController.java
@@ -52,6 +52,17 @@ public class DeliveryController {
 		);
 	}
 
+	@GetMapping("/{deliveryId}")
+	public ResponseEntity<ApiResponse<DeliveryDetailResponse>> getDelivery(
+		@PathVariable UUID deliveryId,
+		@RequestHeader("X-User-Role") String role,
+		@RequestHeader("X-User-Id") UUID userId
+	) {
+		return ResponseEntity.ok(ApiResponse.success(DeliverySuccessCode.DELIVERY_DETAIL_FOUND,
+				DeliveryDetailResponse.from(deliveryQueryService.getDelivery(deliveryId, role, userId)))
+		);
+	}
+
 	@PatchMapping("/{deliveryId}")
 	public ResponseEntity<ApiResponse<UpdateDeliveryResponse>> updateDelivery(
 		@PathVariable UUID deliveryId,
@@ -128,16 +139,5 @@ public class DeliveryController {
 		return ResponseEntity.ok(ApiResponse.success(DeliverySuccessCode.DELIVERY_CANCELLED,
 				ChangeDeliveryStatusResponse.from(deliveryCommandService.cancelDelivery(ChangeDeliveryStatusCommand.of(deliveryId, role, userId)))
 		));
-	}
-
-	@GetMapping("/{deliveryId}")
-	public ResponseEntity<ApiResponse<DeliveryDetailResponse>> getDelivery(
-		@PathVariable UUID deliveryId,
-		@RequestHeader("X-User-Role") String role,
-		@RequestHeader("X-User-Id") UUID userId
-	) {
-		return ResponseEntity.ok(ApiResponse.success(DeliverySuccessCode.DELIVERY_DETAIL_FOUND,
-				DeliveryDetailResponse.from(deliveryQueryService.getDelivery(deliveryId, role, userId)))
-		);
 	}
 }

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/presentation/DeliveryController.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/presentation/DeliveryController.java
@@ -137,7 +137,7 @@ public class DeliveryController {
 		@RequestHeader("X-User-Role") String role
 	) {
 		return ResponseEntity.ok(ApiResponse.success(DeliverySuccessCode.DELIVERY_CANCELLED,
-				ChangeDeliveryStatusResponse.from(deliveryCommandService.cancelDelivery(ChangeDeliveryStatusCommand.of(deliveryId, role, userId)))
+				ChangeDeliveryStatusResponse.from(deliveryCommandFacade.cancelDelivery(ChangeDeliveryStatusCommand.of(deliveryId, role, userId)))
 		));
 	}
 }

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/presentation/DeliveryController.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/presentation/DeliveryController.java
@@ -37,7 +37,7 @@ public class DeliveryController {
 	) {
 		return ResponseEntity.status(DeliverySuccessCode.DELIVERY_CREATED.getStatus())
 			.body(ApiResponse.success(DeliverySuccessCode.DELIVERY_CREATED,
-					CreateDeliveryResponse.from(deliveryCommandFacade.createDelivery(request.toCommand()))
+					CreateDeliveryResponse.from(deliveryCommandFacade.createDelivery(request.toCommand(), role, userId))
 			));
 	}
 

--- a/delivery-service/src/main/java/com/firstlogistics/deliverservice/presentation/DeliverySuccessCode.java
+++ b/delivery-service/src/main/java/com/firstlogistics/deliverservice/presentation/DeliverySuccessCode.java
@@ -17,7 +17,8 @@ public enum DeliverySuccessCode implements SuccessCode {
 	DELIVERY_HUB_ARRIVED(HttpStatus.OK, "DR_S006", "허브에 도착하였습니다."),
 	DELIVERY_COMPANY_STARTED(HttpStatus.OK, "DR_S007", "업체 배송이 시작되었습니다."),
 	DELIVERY_COMPLETED(HttpStatus.OK, "DR_S008", "배송이 완료되었습니다."),
-	DELIVERY_RECEIVED(HttpStatus.OK, "DR_S009", "입고가 완료되었습니다.");
+	DELIVERY_RECEIVED(HttpStatus.OK, "DR_S009", "입고가 완료되었습니다."),
+	DELIVERY_CANCELLED(HttpStatus.OK, "DR_S010", "배송이 취소되었습니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/DeliveryCommandServiceTest.java
+++ b/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/DeliveryCommandServiceTest.java
@@ -1108,68 +1108,21 @@ class DeliveryCommandServiceTest {
 		}
 	}
 
-	// ===== 배송 취소 테스트 (API) =====
+	// ===== 배송 취소 테스트 =====
 
 	@Nested
-	@DisplayName("배송 취소 실패 (API)")
+	@DisplayName("배송 취소 실패")
 	class CancelDeliveryFail {
-
-		@Test
-		@DisplayName("존재하지 않는 배송")
-		void cancelDelivery_fail_deliveryNotFound() {
-			// given
-			UUID deliveryId = UUID.randomUUID();
-			UUID userId = UUID.randomUUID();
-			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
-
-			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.empty());
-
-			// when
-			Throwable throwable = catchThrowable(() -> deliveryCommandService.cancelDelivery(command));
-			log.info("throwable = {}", throwable.getMessage());
-
-			// then
-			assertThat(throwable)
-				.isInstanceOf(DeliveryException.class)
-				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.DELIVERY_NOT_FOUND);
-		}
-
-		@Test
-		@DisplayName("권한 없음 (COMPANY_MANAGER)")
-		void cancelDelivery_fail_accessDenied() {
-			// given
-			UUID deliveryId = UUID.randomUUID();
-			UUID userId = UUID.randomUUID();
-			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.CREATED);
-			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "COMPANY_MANAGER", userId);
-
-			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
-			willThrow(new DeliveryException(DeliveryErrorCode.DELIVERY_ACCESS_DENIED))
-				.given(deliveryPermissionValidator).validate(any(), eq("COMPANY_MANAGER"), eq(userId), any());
-
-			// when
-			Throwable throwable = catchThrowable(() -> deliveryCommandService.cancelDelivery(command));
-			log.info("throwable = {}", throwable.getMessage());
-
-			// then
-			assertThat(throwable)
-				.isInstanceOf(DeliveryException.class)
-				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.DELIVERY_ACCESS_DENIED);
-		}
 
 		@Test
 		@DisplayName("CREATED 아닌 상태 (FOR_HUB_MOVING)")
 		void cancelDelivery_fail_invalidStatus() {
 			// given
 			UUID deliveryId = UUID.randomUUID();
-			UUID userId = UUID.randomUUID();
 			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.FOR_HUB_MOVING);
-			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
-
-			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
 
 			// when
-			Throwable throwable = catchThrowable(() -> deliveryCommandService.cancelDelivery(command));
+			Throwable throwable = catchThrowable(() -> deliveryCommandService.cancelDelivery(delivery));
 			log.info("throwable = {}", throwable.getMessage());
 
 			// then
@@ -1180,7 +1133,7 @@ class DeliveryCommandServiceTest {
 	}
 
 	@Nested
-	@DisplayName("배송 취소 성공 (API)")
+	@DisplayName("배송 취소 성공")
 	class CancelDeliverySuccess {
 
 		@Test
@@ -1188,15 +1141,12 @@ class DeliveryCommandServiceTest {
 		void cancelDelivery_success() {
 			// given
 			UUID deliveryId = UUID.randomUUID();
-			UUID userId = UUID.randomUUID();
 			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.CREATED);
-			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
 
-			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
 			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
 
 			// when
-			ChangeDeliveryStatusResult result = deliveryCommandService.cancelDelivery(command);
+			ChangeDeliveryStatusResult result = deliveryCommandService.cancelDelivery(delivery);
 
 			// then
 			assertThat(result.deliveryId()).isEqualTo(deliveryId);
@@ -1210,15 +1160,12 @@ class DeliveryCommandServiceTest {
 		void cancelDelivery_success_eventPublished() {
 			// given
 			UUID deliveryId = UUID.randomUUID();
-			UUID userId = UUID.randomUUID();
 			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.CREATED);
-			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
 
-			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
 			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
 
 			// when
-			deliveryCommandService.cancelDelivery(command);
+			deliveryCommandService.cancelDelivery(delivery);
 
 			// then
 			ArgumentCaptor<DeliveryStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(DeliveryStatusChangedEvent.class);
@@ -1229,48 +1176,23 @@ class DeliveryCommandServiceTest {
 		}
 	}
 
-	// ===== 배송 취소 테스트 (Kafka - cancelByOrder) =====
+	// ===== 시스템 배송 취소 테스트 =====
 
 	@Nested
-	@DisplayName("주문 취소에 의한 배송 취소 실패")
-	class CancelByOrderFail {
-
-		@Test
-		@DisplayName("존재하지 않는 orderId")
-		void cancelByOrder_fail_deliveryNotFound() {
-			// given
-			UUID orderId = UUID.randomUUID();
-
-			given(deliveryRepository.findByOrderId(orderId)).willReturn(Optional.empty());
-
-			// when
-			Throwable throwable = catchThrowable(() -> deliveryCommandService.cancelByOrder(orderId));
-			log.info("throwable = {}", throwable.getMessage());
-
-			// then
-			assertThat(throwable)
-				.isInstanceOf(DeliveryException.class)
-				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.DELIVERY_NOT_FOUND);
-		}
-	}
-
-	@Nested
-	@DisplayName("주문 취소에 의한 배송 취소 성공")
-	class CancelByOrderSuccess {
+	@DisplayName("시스템 배송 취소 성공")
+	class CancelDeliveryBySystemSuccess {
 
 		@Test
 		@DisplayName("무조건 취소 (어떤 상태든)")
-		void cancelByOrder_success() {
+		void cancelDeliveryBySystem_success() {
 			// given
-			UUID orderId = UUID.randomUUID();
 			UUID deliveryId = UUID.randomUUID();
 			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.FOR_HUB_MOVING);
 
-			given(deliveryRepository.findByOrderId(orderId)).willReturn(Optional.of(delivery));
 			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
 
 			// when
-			deliveryCommandService.cancelByOrder(orderId);
+			deliveryCommandService.cancelDeliveryBySystem(delivery);
 
 			// then
 			ArgumentCaptor<Delivery> captor = ArgumentCaptor.forClass(Delivery.class);
@@ -1279,36 +1201,16 @@ class DeliveryCommandServiceTest {
 		}
 
 		@Test
-		@DisplayName("이미 CANCELLED면 멱등 처리 (중복 취소 무시)")
-		void cancelByOrder_success_alreadyCancelled() {
-			// given
-			UUID orderId = UUID.randomUUID();
-			UUID deliveryId = UUID.randomUUID();
-			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.CANCELLED);
-
-			given(deliveryRepository.findByOrderId(orderId)).willReturn(Optional.of(delivery));
-
-			// when
-			deliveryCommandService.cancelByOrder(orderId);
-
-			// then
-			then(deliveryRepository).should(times(0)).save(any(Delivery.class));
-			then(deliveryEventPublisher).should(times(0)).publishDeliveryStatusChanged(any());
-		}
-
-		@Test
 		@DisplayName("취소 시 이벤트 발행")
-		void cancelByOrder_success_eventPublished() {
+		void cancelDeliveryBySystem_success_eventPublished() {
 			// given
-			UUID orderId = UUID.randomUUID();
 			UUID deliveryId = UUID.randomUUID();
 			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.HUB_WAITING);
 
-			given(deliveryRepository.findByOrderId(orderId)).willReturn(Optional.of(delivery));
 			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
 
 			// when
-			deliveryCommandService.cancelByOrder(orderId);
+			deliveryCommandService.cancelDeliveryBySystem(delivery);
 
 			// then
 			ArgumentCaptor<DeliveryStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(DeliveryStatusChangedEvent.class);

--- a/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/DeliveryCommandServiceTest.java
+++ b/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/DeliveryCommandServiceTest.java
@@ -1236,6 +1236,7 @@ class DeliveryCommandServiceTest {
 			// then
 			ArgumentCaptor<DeliveryStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(DeliveryStatusChangedEvent.class);
 			then(deliveryEventPublisher).should().publishDeliveryStatusChanged(eventCaptor.capture());
+			assertThat(eventCaptor.getValue().deliveryId()).isEqualTo(deliveryId);
 			assertThat(eventCaptor.getValue().status()).isEqualTo("CANCELLED");
 		}
 	}

--- a/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/DeliveryCommandServiceTest.java
+++ b/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/DeliveryCommandServiceTest.java
@@ -1179,15 +1179,36 @@ class DeliveryCommandServiceTest {
 	// ===== 시스템 배송 취소 테스트 =====
 
 	@Nested
+	@DisplayName("시스템 배송 취소 실패")
+	class CancelDeliveryBySystemFail {
+
+		@Test
+		@DisplayName("배송 출발 후 취소 불가")
+		void cancelDeliveryBySystem_fail_invalidStatusTransition() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.FOR_HUB_MOVING);
+
+			// when
+			Throwable throwable = catchThrowable(() -> deliveryCommandService.cancelDeliveryBySystem(delivery));
+
+			// then
+			assertThat(throwable)
+				.isInstanceOf(DeliveryException.class)
+				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.INVALID_STATUS_TRANSITION);
+		}
+	}
+
+	@Nested
 	@DisplayName("시스템 배송 취소 성공")
 	class CancelDeliveryBySystemSuccess {
 
 		@Test
-		@DisplayName("무조건 취소 (어떤 상태든)")
+		@DisplayName("CREATED 상태에서 취소 성공")
 		void cancelDeliveryBySystem_success() {
 			// given
 			UUID deliveryId = UUID.randomUUID();
-			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.FOR_HUB_MOVING);
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.CREATED);
 
 			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
 
@@ -1205,7 +1226,7 @@ class DeliveryCommandServiceTest {
 		void cancelDeliveryBySystem_success_eventPublished() {
 			// given
 			UUID deliveryId = UUID.randomUUID();
-			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.HUB_WAITING);
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.CREATED);
 
 			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
 

--- a/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/DeliveryCommandServiceTest.java
+++ b/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/DeliveryCommandServiceTest.java
@@ -1108,6 +1108,215 @@ class DeliveryCommandServiceTest {
 		}
 	}
 
+	// ===== 배송 취소 테스트 (API) =====
+
+	@Nested
+	@DisplayName("배송 취소 실패 (API)")
+	class CancelDeliveryFail {
+
+		@Test
+		@DisplayName("존재하지 않는 배송")
+		void cancelDelivery_fail_deliveryNotFound() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.empty());
+
+			// when
+			Throwable throwable = catchThrowable(() -> deliveryCommandService.cancelDelivery(command));
+			log.info("throwable = {}", throwable.getMessage());
+
+			// then
+			assertThat(throwable)
+				.isInstanceOf(DeliveryException.class)
+				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.DELIVERY_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("권한 없음 (COMPANY_MANAGER)")
+		void cancelDelivery_fail_accessDenied() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.CREATED);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "COMPANY_MANAGER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+			willThrow(new DeliveryException(DeliveryErrorCode.DELIVERY_ACCESS_DENIED))
+				.given(deliveryPermissionValidator).validate(any(), eq("COMPANY_MANAGER"), eq(userId), any());
+
+			// when
+			Throwable throwable = catchThrowable(() -> deliveryCommandService.cancelDelivery(command));
+			log.info("throwable = {}", throwable.getMessage());
+
+			// then
+			assertThat(throwable)
+				.isInstanceOf(DeliveryException.class)
+				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.DELIVERY_ACCESS_DENIED);
+		}
+
+		@Test
+		@DisplayName("CREATED 아닌 상태 (FOR_HUB_MOVING)")
+		void cancelDelivery_fail_invalidStatus() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.FOR_HUB_MOVING);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+
+			// when
+			Throwable throwable = catchThrowable(() -> deliveryCommandService.cancelDelivery(command));
+			log.info("throwable = {}", throwable.getMessage());
+
+			// then
+			assertThat(throwable)
+				.isInstanceOf(DeliveryException.class)
+				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.INVALID_STATUS_TRANSITION);
+		}
+	}
+
+	@Nested
+	@DisplayName("배송 취소 성공 (API)")
+	class CancelDeliverySuccess {
+
+		@Test
+		@DisplayName("CREATED → CANCELLED")
+		void cancelDelivery_success() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.CREATED);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
+
+			// when
+			ChangeDeliveryStatusResult result = deliveryCommandService.cancelDelivery(command);
+
+			// then
+			assertThat(result.deliveryId()).isEqualTo(deliveryId);
+			ArgumentCaptor<Delivery> captor = ArgumentCaptor.forClass(Delivery.class);
+			then(deliveryRepository).should().save(captor.capture());
+			assertThat(captor.getValue().getStatus()).isEqualTo(DeliveryStatus.CANCELLED);
+		}
+
+		@Test
+		@DisplayName("취소 시 이벤트 발행")
+		void cancelDelivery_success_eventPublished() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.CREATED);
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId))).willReturn(Optional.of(delivery));
+			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
+
+			// when
+			deliveryCommandService.cancelDelivery(command);
+
+			// then
+			ArgumentCaptor<DeliveryStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(DeliveryStatusChangedEvent.class);
+			then(deliveryEventPublisher).should().publishDeliveryStatusChanged(eventCaptor.capture());
+			DeliveryStatusChangedEvent captured = eventCaptor.getValue();
+			assertThat(captured.status()).isEqualTo("CANCELLED");
+			assertThat(captured.deliveryId()).isEqualTo(deliveryId);
+		}
+	}
+
+	// ===== 배송 취소 테스트 (Kafka - cancelByOrder) =====
+
+	@Nested
+	@DisplayName("주문 취소에 의한 배송 취소 실패")
+	class CancelByOrderFail {
+
+		@Test
+		@DisplayName("존재하지 않는 orderId")
+		void cancelByOrder_fail_deliveryNotFound() {
+			// given
+			UUID orderId = UUID.randomUUID();
+
+			given(deliveryRepository.findByOrderId(orderId)).willReturn(Optional.empty());
+
+			// when
+			Throwable throwable = catchThrowable(() -> deliveryCommandService.cancelByOrder(orderId));
+			log.info("throwable = {}", throwable.getMessage());
+
+			// then
+			assertThat(throwable)
+				.isInstanceOf(DeliveryException.class)
+				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.DELIVERY_NOT_FOUND);
+		}
+	}
+
+	@Nested
+	@DisplayName("주문 취소에 의한 배송 취소 성공")
+	class CancelByOrderSuccess {
+
+		@Test
+		@DisplayName("무조건 취소 (어떤 상태든)")
+		void cancelByOrder_success() {
+			// given
+			UUID orderId = UUID.randomUUID();
+			UUID deliveryId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.FOR_HUB_MOVING);
+
+			given(deliveryRepository.findByOrderId(orderId)).willReturn(Optional.of(delivery));
+			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
+
+			// when
+			deliveryCommandService.cancelByOrder(orderId);
+
+			// then
+			ArgumentCaptor<Delivery> captor = ArgumentCaptor.forClass(Delivery.class);
+			then(deliveryRepository).should().save(captor.capture());
+			assertThat(captor.getValue().getStatus()).isEqualTo(DeliveryStatus.CANCELLED);
+		}
+
+		@Test
+		@DisplayName("이미 CANCELLED면 멱등 처리 (중복 취소 무시)")
+		void cancelByOrder_success_alreadyCancelled() {
+			// given
+			UUID orderId = UUID.randomUUID();
+			UUID deliveryId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.CANCELLED);
+
+			given(deliveryRepository.findByOrderId(orderId)).willReturn(Optional.of(delivery));
+
+			// when
+			deliveryCommandService.cancelByOrder(orderId);
+
+			// then
+			then(deliveryRepository).should(times(0)).save(any(Delivery.class));
+			then(deliveryEventPublisher).should(times(0)).publishDeliveryStatusChanged(any());
+		}
+
+		@Test
+		@DisplayName("취소 시 이벤트 발행")
+		void cancelByOrder_success_eventPublished() {
+			// given
+			UUID orderId = UUID.randomUUID();
+			UUID deliveryId = UUID.randomUUID();
+			Delivery delivery = stubDeliveryWithRoutes(deliveryId, DeliveryStatus.HUB_WAITING);
+
+			given(deliveryRepository.findByOrderId(orderId)).willReturn(Optional.of(delivery));
+			given(deliveryRepository.save(any(Delivery.class))).willAnswer(inv -> inv.getArgument(0));
+
+			// when
+			deliveryCommandService.cancelByOrder(orderId);
+
+			// then
+			ArgumentCaptor<DeliveryStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(DeliveryStatusChangedEvent.class);
+			then(deliveryEventPublisher).should().publishDeliveryStatusChanged(eventCaptor.capture());
+			assertThat(eventCaptor.getValue().status()).isEqualTo("CANCELLED");
+		}
+	}
+
 	// --- 배송 수정 테스트 픽스처 ---
 
 	private static final UUID STUB_SOURCE_HUB_ID = UUID.randomUUID();

--- a/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/facade/DeliveryCommandFacadeTest.java
+++ b/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/facade/DeliveryCommandFacadeTest.java
@@ -1,14 +1,27 @@
 package com.firstlogistics.deliverservice.application.facade;
 
 import com.firstlogistics.deliverservice.application.DeliveryCommandService;
+import com.firstlogistics.deliverservice.application.dto.command.ChangeDeliveryStatusCommand;
 import com.firstlogistics.deliverservice.application.dto.command.CreateDeliveryCommand;
+import com.firstlogistics.deliverservice.application.dto.result.ChangeDeliveryStatusResult;
+import com.firstlogistics.deliverservice.application.dto.result.CreateDeliveryResult;
+import com.firstlogistics.deliverservice.application.permission.DeliveryAccessContext;
 import com.firstlogistics.deliverservice.application.permission.DeliveryPermissionValidator;
+import com.firstlogistics.deliverservice.domain.entity.Delivery;
+import com.firstlogistics.deliverservice.domain.entity.DeliveryRoute;
+import com.firstlogistics.deliverservice.domain.enums.DeliveryStatus;
+import com.firstlogistics.deliverservice.domain.enums.UserRole;
 import com.firstlogistics.deliverservice.domain.exception.DeliveryErrorCode;
 import com.firstlogistics.deliverservice.domain.exception.DeliveryException;
 import com.firstlogistics.deliverservice.domain.repository.DeliveryRepository;
+import com.firstlogistics.deliverservice.domain.vo.Address;
+import com.firstlogistics.deliverservice.domain.vo.DeliveryId;
+import com.firstlogistics.deliverservice.domain.vo.DeliveryManagerId;
 import com.firstlogistics.deliverservice.application.port.CompanyPort;
 import com.firstlogistics.deliverservice.application.port.HubPort;
 import com.firstlogistics.deliverservice.application.port.dto.CompanyResponse;
+import com.firstlogistics.deliverservice.application.port.dto.HubRouteResponse;
+import com.firstlogistics.deliverservice.application.port.dto.HubRouteStepResponse;
 import com.firstlogistics.deliverservice.application.port.DistributedLockPort;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -21,15 +34,26 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 
 @Slf4j
 @ExtendWith(MockitoExtension.class)
 class DeliveryCommandFacadeTest {
+
+	private static final UUID STUB_SOURCE_HUB_ID = UUID.randomUUID();
+	private static final UUID STUB_DESTINATION_HUB_ID = UUID.randomUUID();
+	private static final UUID STUB_ROUTE_MANAGER_ID = UUID.randomUUID();
 
 	@Mock
 	private DeliveryCommandService deliveryCommandService;
@@ -52,30 +76,27 @@ class DeliveryCommandFacadeTest {
 	@InjectMocks
 	private DeliveryCommandFacade deliveryCommandFacade;
 
+	// ─── createDeliveryBySystem ─────────────────────────────────────────
+
 	@Nested
-	@DisplayName("배송 생성 실패")
-	class CreateDeliveryFail {
+	@DisplayName("createDeliveryBySystem 실패")
+	class CreateDeliveryBySystemFail {
 
 		@Test
 		@DisplayName("존재하지 않는 수령업체 ID")
-		void createDelivery_fail_receiverCompanyNotFound() {
+		void createDeliveryBySystem_fail_receiverCompanyNotFound() {
 			// given
-			UUID orderId = UUID.randomUUID();
 			UUID supplierCompanyId = UUID.randomUUID();
-			UUID supplierManagerId = UUID.randomUUID();
-			UUID supplierHubId = UUID.randomUUID();
 			UUID receiverCompanyId = UUID.randomUUID();
-			UUID receiverManagerId = UUID.randomUUID();
-			CreateDeliveryCommand command = stubCommand(orderId, supplierCompanyId, supplierManagerId, receiverCompanyId, receiverManagerId);
+			CreateDeliveryCommand command = stubCommand(supplierCompanyId, receiverCompanyId);
 
 			given(companyPort.getCompany(supplierCompanyId))
-				.willReturn(new CompanyResponse(supplierCompanyId, supplierHubId, "공급업체", "서울시 송파구 올림픽로 300", "A동 1층"));
+				.willReturn(new CompanyResponse(supplierCompanyId, STUB_SOURCE_HUB_ID, "공급업체", "서울시 송파구 올림픽로 300", "A동 1층"));
 			given(companyPort.getCompany(receiverCompanyId))
 				.willThrow(new DeliveryException(DeliveryErrorCode.COMPANY_NOT_FOUND));
 
 			// when
 			Throwable throwable = catchThrowable(() -> deliveryCommandFacade.createDeliveryBySystem(command));
-			log.info("throwable = {}", throwable.getMessage());
 
 			// then
 			assertThat(throwable)
@@ -85,27 +106,21 @@ class DeliveryCommandFacadeTest {
 
 		@Test
 		@DisplayName("존재하지 않는 허브 (경로 계산 실패)")
-		void createDelivery_fail_hubNotFound() {
+		void createDeliveryBySystem_fail_hubNotFound() {
 			// given
-			UUID orderId = UUID.randomUUID();
 			UUID supplierCompanyId = UUID.randomUUID();
-			UUID supplierManagerId = UUID.randomUUID();
-			UUID supplierHubId = UUID.randomUUID();
 			UUID receiverCompanyId = UUID.randomUUID();
-			UUID receiverManagerId = UUID.randomUUID();
-			UUID destinationHubId = UUID.randomUUID();
-			CreateDeliveryCommand command = stubCommand(orderId, supplierCompanyId, supplierManagerId, receiverCompanyId, receiverManagerId);
+			CreateDeliveryCommand command = stubCommand(supplierCompanyId, receiverCompanyId);
 
 			given(companyPort.getCompany(supplierCompanyId))
-				.willReturn(new CompanyResponse(supplierCompanyId, supplierHubId, "공급업체", "서울시 송파구 올림픽로 300", "A동 1층"));
+				.willReturn(new CompanyResponse(supplierCompanyId, STUB_SOURCE_HUB_ID, "공급업체", "서울시 송파구 올림픽로 300", "A동 1층"));
 			given(companyPort.getCompany(receiverCompanyId))
-				.willReturn(new CompanyResponse(receiverCompanyId, destinationHubId, "수령업체", "서울시 강남구 테헤란로 123", "101동 202호"));
-			given(hubPort.getHubRoute(supplierHubId, destinationHubId, receiverCompanyId))
+				.willReturn(new CompanyResponse(receiverCompanyId, STUB_DESTINATION_HUB_ID, "수령업체", "서울시 강남구 테헤란로 123", "101동 202호"));
+			given(hubPort.getHubRoute(STUB_SOURCE_HUB_ID, STUB_DESTINATION_HUB_ID, receiverCompanyId))
 				.willThrow(new DeliveryException(DeliveryErrorCode.HUB_NOT_FOUND));
 
 			// when
 			Throwable throwable = catchThrowable(() -> deliveryCommandFacade.createDeliveryBySystem(command));
-			log.info("throwable = {}", throwable.getMessage());
 
 			// then
 			assertThat(throwable)
@@ -114,22 +129,246 @@ class DeliveryCommandFacadeTest {
 		}
 	}
 
-	private CreateDeliveryCommand stubCommand(
-		UUID orderId,
-		UUID supplierCompanyId,
-		UUID supplierManagerId,
-		UUID receiverCompanyId,
-		UUID receiverManagerId
-	) {
+	// ─── createDelivery (권한 검증 포함) ────────────────────────────────
+
+	@Nested
+	@DisplayName("createDelivery 실패")
+	class CreateDeliveryFail {
+
+		@Test
+		@DisplayName("MASTER 외 권한으로 배송 생성 시도")
+		void createDelivery_fail_accessDenied() {
+			// given
+			UUID supplierCompanyId = UUID.randomUUID();
+			UUID receiverCompanyId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			String role = "HUB_MANAGER";
+			CreateDeliveryCommand command = stubCommand(supplierCompanyId, receiverCompanyId);
+
+			doThrow(new DeliveryException(DeliveryErrorCode.DELIVERY_ACCESS_DENIED))
+				.when(deliveryPermissionValidator).validateRole(role, Set.of(UserRole.MASTER));
+
+			// when
+			Throwable throwable = catchThrowable(() -> deliveryCommandFacade.createDelivery(command, role, userId));
+
+			// then
+			assertThat(throwable)
+				.isInstanceOf(DeliveryException.class)
+				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.DELIVERY_ACCESS_DENIED);
+			then(companyPort).should(never()).getCompany(any());
+		}
+	}
+
+	@Nested
+	@DisplayName("createDelivery 성공")
+	class CreateDeliverySuccess {
+
+		@Test
+		@DisplayName("MASTER 권한으로 배송 생성 성공")
+		void createDelivery_success() {
+			// given
+			UUID supplierCompanyId = UUID.randomUUID();
+			UUID receiverCompanyId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			String role = "MASTER";
+			CreateDeliveryCommand command = stubCommand(supplierCompanyId, receiverCompanyId);
+			UUID deliveryId = UUID.randomUUID();
+			CreateDeliveryResult expectedResult = new CreateDeliveryResult(deliveryId);
+
+			given(companyPort.getCompany(supplierCompanyId))
+				.willReturn(new CompanyResponse(supplierCompanyId, STUB_SOURCE_HUB_ID, "공급업체", "서울시 송파구 올림픽로 300", "A동 1층"));
+			given(companyPort.getCompany(receiverCompanyId))
+				.willReturn(new CompanyResponse(receiverCompanyId, STUB_DESTINATION_HUB_ID, "수령업체", "서울시 강남구 테헤란로 123", "101동 202호"));
+			given(hubPort.getHubRoute(STUB_SOURCE_HUB_ID, STUB_DESTINATION_HUB_ID, receiverCompanyId))
+				.willReturn(new HubRouteResponse(List.of(
+					new HubRouteStepResponse(STUB_SOURCE_HUB_ID, STUB_DESTINATION_HUB_ID, 10000, 30)
+				)));
+			given(distributedLockPort.executeWithMultiLock(any(), any()))
+				.willReturn(expectedResult);
+
+			// when
+			CreateDeliveryResult result = deliveryCommandFacade.createDelivery(command, role, userId);
+
+			// then
+			assertThat(result.deliveryId()).isEqualTo(deliveryId);
+		}
+	}
+
+	// ─── cancelDelivery (권한 검증 포함) ────────────────────────────────
+
+	@Nested
+	@DisplayName("cancelDelivery 실패")
+	class CancelDeliveryFail {
+
+		@Test
+		@DisplayName("배송 미존재")
+		void cancelDelivery_fail_deliveryNotFound() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, "MASTER", userId);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId)))
+				.willReturn(Optional.empty());
+
+			// when
+			Throwable throwable = catchThrowable(() -> deliveryCommandFacade.cancelDelivery(command));
+
+			// then
+			assertThat(throwable)
+				.isInstanceOf(DeliveryException.class)
+				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.DELIVERY_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("허용되지 않은 권한으로 취소 시도")
+		void cancelDelivery_fail_accessDenied() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			String role = "COMPANY_MANAGER";
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, role, userId);
+			Delivery delivery = stubDelivery(deliveryId, DeliveryStatus.CREATED);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId)))
+				.willReturn(Optional.of(delivery));
+			doThrow(new DeliveryException(DeliveryErrorCode.DELIVERY_ACCESS_DENIED))
+				.when(deliveryPermissionValidator).validate(
+					any(DeliveryAccessContext.class), eq(role), eq(userId),
+					eq(Set.of(UserRole.MASTER, UserRole.HUB_MANAGER))
+				);
+
+			// when
+			Throwable throwable = catchThrowable(() -> deliveryCommandFacade.cancelDelivery(command));
+
+			// then
+			assertThat(throwable)
+				.isInstanceOf(DeliveryException.class)
+				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.DELIVERY_ACCESS_DENIED);
+			then(deliveryCommandService).should(never()).cancelDelivery(any());
+		}
+	}
+
+	@Nested
+	@DisplayName("cancelDelivery 성공")
+	class CancelDeliverySuccess {
+
+		@Test
+		@DisplayName("MASTER 권한으로 배송 취소 성공")
+		void cancelDelivery_success() {
+			// given
+			UUID deliveryId = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			String role = "MASTER";
+			ChangeDeliveryStatusCommand command = ChangeDeliveryStatusCommand.of(deliveryId, role, userId);
+			Delivery delivery = stubDelivery(deliveryId, DeliveryStatus.CREATED);
+
+			given(deliveryRepository.findById(DeliveryId.of(deliveryId)))
+				.willReturn(Optional.of(delivery));
+			given(deliveryCommandService.cancelDelivery(delivery))
+				.willReturn(new ChangeDeliveryStatusResult(deliveryId));
+
+			// when
+			ChangeDeliveryStatusResult result = deliveryCommandFacade.cancelDelivery(command);
+
+			// then
+			assertThat(result.deliveryId()).isEqualTo(deliveryId);
+		}
+	}
+
+	// ─── cancelDeliveryBySystem ─────────────────────────────────────────
+
+	@Nested
+	@DisplayName("cancelDeliveryBySystem 실패")
+	class CancelDeliveryBySystemFail {
+
+		@Test
+		@DisplayName("배송 미존재")
+		void cancelDeliveryBySystem_fail_deliveryNotFound() {
+			// given
+			UUID orderId = UUID.randomUUID();
+
+			given(deliveryRepository.findByOrderId(orderId))
+				.willReturn(Optional.empty());
+
+			// when
+			Throwable throwable = catchThrowable(() -> deliveryCommandFacade.cancelDeliveryBySystem(orderId));
+
+			// then
+			assertThat(throwable)
+				.isInstanceOf(DeliveryException.class)
+				.hasFieldOrPropertyWithValue("errorCode", DeliveryErrorCode.DELIVERY_NOT_FOUND);
+		}
+	}
+
+	@Nested
+	@DisplayName("cancelDeliveryBySystem 성공")
+	class CancelDeliveryBySystemSuccess {
+
+		@Test
+		@DisplayName("정상 취소")
+		void cancelDeliveryBySystem_success() {
+			// given
+			UUID orderId = UUID.randomUUID();
+			UUID deliveryId = UUID.randomUUID();
+			Delivery delivery = stubDelivery(deliveryId, DeliveryStatus.FOR_HUB_MOVING);
+
+			given(deliveryRepository.findByOrderId(orderId))
+				.willReturn(Optional.of(delivery));
+
+			// when
+			deliveryCommandFacade.cancelDeliveryBySystem(orderId);
+
+			// then
+			then(deliveryCommandService).should().cancelDeliveryBySystem(delivery);
+		}
+
+		@Test
+		@DisplayName("이미 취소된 배송 - 멱등하게 무시")
+		void cancelDeliveryBySystem_success_alreadyCancelled() {
+			// given
+			UUID orderId = UUID.randomUUID();
+			UUID deliveryId = UUID.randomUUID();
+			Delivery delivery = stubDelivery(deliveryId, DeliveryStatus.CANCELLED);
+
+			given(deliveryRepository.findByOrderId(orderId))
+				.willReturn(Optional.of(delivery));
+
+			// when
+			deliveryCommandFacade.cancelDeliveryBySystem(orderId);
+
+			// then
+			then(deliveryCommandService).should(never()).cancelDeliveryBySystem(any());
+		}
+	}
+
+	// ─── 헬퍼 ──────────────────────────────────────────────────────────
+
+	private Delivery stubDelivery(UUID deliveryId, DeliveryStatus status) {
+		DeliveryId id = DeliveryId.of(deliveryId);
+		DeliveryRoute route = DeliveryRoute.create(id, 0, STUB_SOURCE_HUB_ID, STUB_DESTINATION_HUB_ID, 10000, 30);
+		route.assignManager(STUB_ROUTE_MANAGER_ID);
+		return Delivery.reconstitute(
+			id, UUID.randomUUID(), status,
+			STUB_SOURCE_HUB_ID, STUB_DESTINATION_HUB_ID,
+			Address.of("서울시 강남구 테헤란로 123", "101호"),
+			null,
+			UUID.randomUUID(), "slack-receiver", UUID.randomUUID(),
+			DeliveryManagerId.generate(), STUB_SOURCE_HUB_ID,
+			List.of(route)
+		);
+	}
+
+	private CreateDeliveryCommand stubCommand(UUID supplierCompanyId, UUID receiverCompanyId) {
 		return new CreateDeliveryCommand(
-			orderId,
+			UUID.randomUUID(),
 			LocalDateTime.now(),
 			LocalDateTime.now().plusDays(3),
 			"요청사항",
 			supplierCompanyId,
-			supplierManagerId,
+			UUID.randomUUID(),
 			receiverCompanyId,
-			receiverManagerId,
+			UUID.randomUUID(),
 			"서울시 강남구 테헤란로 123",
 			"101호",
 			List.of(new CreateDeliveryCommand.OrderItemInfo(UUID.randomUUID(), "마른 오징어", 50, 10000L))

--- a/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/facade/DeliveryCommandFacadeTest.java
+++ b/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/facade/DeliveryCommandFacadeTest.java
@@ -2,8 +2,10 @@ package com.firstlogistics.deliverservice.application.facade;
 
 import com.firstlogistics.deliverservice.application.DeliveryCommandService;
 import com.firstlogistics.deliverservice.application.dto.command.CreateDeliveryCommand;
+import com.firstlogistics.deliverservice.application.permission.DeliveryPermissionValidator;
 import com.firstlogistics.deliverservice.domain.exception.DeliveryErrorCode;
 import com.firstlogistics.deliverservice.domain.exception.DeliveryException;
+import com.firstlogistics.deliverservice.domain.repository.DeliveryRepository;
 import com.firstlogistics.deliverservice.application.port.CompanyPort;
 import com.firstlogistics.deliverservice.application.port.HubPort;
 import com.firstlogistics.deliverservice.application.port.dto.CompanyResponse;
@@ -39,10 +41,16 @@ class DeliveryCommandFacadeTest {
 	private HubPort hubPort;
 
 	@Mock
+	private DeliveryRepository deliveryRepository;
+
+	@Mock
+	private DeliveryPermissionValidator deliveryPermissionValidator;
+
+	@Mock
 	private DistributedLockPort distributedLockPort;
 
 	@InjectMocks
-	private DeliveryCommandFacade deliveryCreateFacade;
+	private DeliveryCommandFacade deliveryCommandFacade;
 
 	@Nested
 	@DisplayName("배송 생성 실패")
@@ -66,7 +74,7 @@ class DeliveryCommandFacadeTest {
 				.willThrow(new DeliveryException(DeliveryErrorCode.COMPANY_NOT_FOUND));
 
 			// when
-			Throwable throwable = catchThrowable(() -> deliveryCreateFacade.createDelivery(command));
+			Throwable throwable = catchThrowable(() -> deliveryCommandFacade.createDeliveryBySystem(command));
 			log.info("throwable = {}", throwable.getMessage());
 
 			// then
@@ -96,7 +104,7 @@ class DeliveryCommandFacadeTest {
 				.willThrow(new DeliveryException(DeliveryErrorCode.HUB_NOT_FOUND));
 
 			// when
-			Throwable throwable = catchThrowable(() -> deliveryCreateFacade.createDelivery(command));
+			Throwable throwable = catchThrowable(() -> deliveryCommandFacade.createDeliveryBySystem(command));
 			log.info("throwable = {}", throwable.getMessage());
 
 			// then

--- a/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/facade/DeliveryCommandFacadeTest.java
+++ b/delivery-service/src/test/java/com/firstlogistics/deliverservice/application/facade/DeliveryCommandFacadeTest.java
@@ -311,7 +311,7 @@ class DeliveryCommandFacadeTest {
 			// given
 			UUID orderId = UUID.randomUUID();
 			UUID deliveryId = UUID.randomUUID();
-			Delivery delivery = stubDelivery(deliveryId, DeliveryStatus.FOR_HUB_MOVING);
+			Delivery delivery = stubDelivery(deliveryId, DeliveryStatus.CREATED);
 
 			given(deliveryRepository.findByOrderId(orderId))
 				.willReturn(Optional.of(delivery));

--- a/delivery-service/src/test/java/com/firstlogistics/deliverservice/infrastructure/messaging/consumer/OrderEventKafkaConsumerTest.java
+++ b/delivery-service/src/test/java/com/firstlogistics/deliverservice/infrastructure/messaging/consumer/OrderEventKafkaConsumerTest.java
@@ -84,7 +84,7 @@ class OrderEventKafkaConsumerTest {
 
 			// then
 			await().atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
-					then(deliveryCommandFacade).should().createDelivery(any(CreateDeliveryCommand.class))
+					then(deliveryCommandFacade).should().createDeliveryBySystem(any(CreateDeliveryCommand.class))
 			);
 		}
 
@@ -105,7 +105,7 @@ class OrderEventKafkaConsumerTest {
 			// createDelivery 호출 여부를 확정하기 전에 단언이 통과하는 레이스 컨디션이 발생한다.
 			await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
 				then(deliveryQueryService).should().existsByOrderId(event.orderId());
-				then(deliveryCommandFacade).should(never()).createDelivery(any());
+				then(deliveryCommandFacade).should(never()).createDeliveryBySystem(any());
 			});
 		}
 
@@ -115,7 +115,7 @@ class OrderEventKafkaConsumerTest {
 			// given
 			OrderAcceptedEvent event = createEvent();
 			given(deliveryQueryService.existsByOrderId(event.orderId())).willReturn(false);
-			given(deliveryCommandFacade.createDelivery(any()))
+			given(deliveryCommandFacade.createDeliveryBySystem(any()))
 					.willThrow(new DeliveryCreationException(DeliveryErrorCode.HUB_NOT_FOUND));
 
 			// subscribe 대신 assign + seekToBeginning: 그룹 조인 없이 바로 파티션 읽기 (타이밍 문제 방지)

--- a/delivery-service/src/test/java/com/firstlogistics/deliverservice/infrastructure/messaging/producer/DeliveryEventKafkaProducerTest.java
+++ b/delivery-service/src/test/java/com/firstlogistics/deliverservice/infrastructure/messaging/producer/DeliveryEventKafkaProducerTest.java
@@ -80,6 +80,7 @@ class DeliveryEventKafkaProducerTest {
         );
         DeliveryCreatedEvent.DeliveryInfo deliveryInfo = DeliveryCreatedEvent.DeliveryInfo.of(
             deliveryId,
+            UUID.randomUUID(),
             "수령인",
             receiverSlackId,
             "서울시 강남구 테헤란로 123",

--- a/delivery-service/src/test/java/com/firstlogistics/deliverservice/infrastructure/messaging/producer/DeliveryEventKafkaProducerTest.java
+++ b/delivery-service/src/test/java/com/firstlogistics/deliverservice/infrastructure/messaging/producer/DeliveryEventKafkaProducerTest.java
@@ -83,6 +83,8 @@ class DeliveryEventKafkaProducerTest {
             UUID.randomUUID(),
             "수령인",
             receiverSlackId,
+            "receiver@test.com",
+            "010-1111-1111",
             "서울시 강남구 테헤란로 123",
             "101호",
             List.of(),


### PR DESCRIPTION
### 📌 관련 이슈
- close #132 
- 
### 💡 작업 내용
- 
-

### 🔍 변경 이유
- 

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 배송 관리 기능 개선

* **새로운 기능**
  * 사용자 취소 및 시스템 자동 취소 흐름 추가(중복 호출에 대한 무시 처리 포함)
  * 주문 취소(order.cancelled) 이벤트 수신 및 DLT 전송 지원
  * 배송 생성 이벤트에 현재 허브(currentHubId) 및 수신자 연락처 포함

* **API 변경**
  * 배송 상세 조회 엔드포인트 추가 (GET)
  * 배송 취소 엔드포인트 추가 (POST /{deliveryId}/cancel)

* **권한·안정성**
  * 역할 기반 검증 강화 및 권한 검사 분리
  * 취소 관련 상태 정리(CANCEL_REQUESTED 제거)

* **테스트**
  * 취소 시나리오에 대한 단위 테스트 추가 및 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->