### PR TITLE
feat: 주문 조회 기능 구현

### DIFF
--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -2,6 +2,16 @@ plugins {
     id 'org.springframework.boot'
 }
 
+def generated = layout.buildDirectory.dir("generated/querydsl").get().asFile
+
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+sourceSets {
+    main.java.srcDirs += [generated]
+}
+
 dependencies {
     implementation project(':common')
     implementation project(':common-jpa')
@@ -10,6 +20,11 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    implementation "com.querydsl:querydsl-jpa:${QUERY_DSL_VERSION}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${QUERY_DSL_VERSION}:jakarta"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 
     implementation 'org.springframework.kafka:spring-kafka'
 
@@ -31,3 +46,6 @@ dependencyManagement {
     }
 }
 
+clean {
+    delete file(generated)
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/application/OrderCommandService.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/application/OrderCommandService.java
@@ -1,6 +1,6 @@
 package com.firstlogistics.orderservice.application;
 
-import com.firstlogistics.orderservice.application.dto.CreateOrderCommand;
+import com.firstlogistics.orderservice.application.dto.command.CreateOrderCommand;
 import com.firstlogistics.orderservice.application.port.CompanyPort;
 import com.firstlogistics.orderservice.domain.entity.Order;
 import com.firstlogistics.orderservice.domain.enums.OrderCancelType;

--- a/order-service/src/main/java/com/firstlogistics/orderservice/application/OrderQueryService.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/application/OrderQueryService.java
@@ -1,0 +1,25 @@
+package com.firstlogistics.orderservice.application;
+
+import com.firstlogistics.orderservice.application.dto.query.OrderSearchQuery;
+import com.firstlogistics.orderservice.application.dto.result.OrderSummaryResult;
+import com.firstlogistics.orderservice.domain.repository.OrderQueryRepository;
+import com.firstlogistics.orderservice.domain.service.RoleCheck;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OrderQueryService {
+
+    private final OrderQueryRepository orderQueryRepository;
+    private final RoleCheck roleCheck;
+
+    public Page<OrderSummaryResult> getOrders(OrderSearchQuery query, Pageable pageable) {
+        return orderQueryRepository.findAll(OrderSearchQuery.toSpec(query, roleCheck), pageable)
+                .map(OrderSummaryResult::from);
+    }
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/application/OrderQueryService.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/application/OrderQueryService.java
@@ -14,11 +14,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OrderQueryService {
 
     private final OrderQueryRepository orderQueryRepository;

--- a/order-service/src/main/java/com/firstlogistics/orderservice/application/OrderQueryService.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/application/OrderQueryService.java
@@ -36,7 +36,11 @@ public class OrderQueryService {
         Order order =  orderRepository.findById(OrderId.of(orderId))
                 .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
 
-        if (!roleCheck.canView(order)) {
+        if (!roleCheck.canView(order.getId(),
+                order.getSupplier().hubId(),
+                order.getSupplier().managerId(),
+                order.getReceiver().managerId()
+        )) {
             throw new OrderException(OrderErrorCode.UNAUTHORIZED_ACCESS);
         }
 

--- a/order-service/src/main/java/com/firstlogistics/orderservice/application/OrderQueryService.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/application/OrderQueryService.java
@@ -1,25 +1,43 @@
 package com.firstlogistics.orderservice.application;
 
 import com.firstlogistics.orderservice.application.dto.query.OrderSearchQuery;
+import com.firstlogistics.orderservice.application.dto.result.OrderDetailResult;
 import com.firstlogistics.orderservice.application.dto.result.OrderSummaryResult;
+import com.firstlogistics.orderservice.domain.entity.Order;
+import com.firstlogistics.orderservice.domain.exception.OrderErrorCode;
+import com.firstlogistics.orderservice.domain.exception.OrderException;
 import com.firstlogistics.orderservice.domain.repository.OrderQueryRepository;
+import com.firstlogistics.orderservice.domain.repository.OrderRepository;
 import com.firstlogistics.orderservice.domain.service.RoleCheck;
+import com.firstlogistics.orderservice.domain.vo.OrderId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class OrderQueryService {
 
     private final OrderQueryRepository orderQueryRepository;
+    private final OrderRepository orderRepository;
     private final RoleCheck roleCheck;
 
     public Page<OrderSummaryResult> getOrders(OrderSearchQuery query, Pageable pageable) {
         return orderQueryRepository.findAll(OrderSearchQuery.toSpec(query, roleCheck), pageable)
                 .map(OrderSummaryResult::from);
+    }
+
+    public OrderDetailResult getOrder(UUID orderId) {
+        Order order =  orderRepository.findById(OrderId.of(orderId))
+                .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        if (!roleCheck.canView(order)) {
+            throw new OrderException(OrderErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        return OrderDetailResult.from(order);
     }
 }

--- a/order-service/src/main/java/com/firstlogistics/orderservice/application/dto/command/CreateOrderCommand.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/application/dto/command/CreateOrderCommand.java
@@ -1,4 +1,4 @@
-package com.firstlogistics.orderservice.application.dto;
+package com.firstlogistics.orderservice.application.dto.command;
 
 import com.firstlogistics.orderservice.domain.vo.OrderItemInput;
 

--- a/order-service/src/main/java/com/firstlogistics/orderservice/application/dto/query/OrderSearchQuery.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/application/dto/query/OrderSearchQuery.java
@@ -1,0 +1,60 @@
+package com.firstlogistics.orderservice.application.dto.query;
+
+import com.firstlogistics.orderservice.domain.enums.OrderStatus;
+import com.firstlogistics.orderservice.domain.service.RoleCheck;
+import com.firstlogistics.orderservice.domain.specification.OrderSearchSpec;
+import com.firstlogistics.orderservice.domain.specification.OrderSearchType;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record OrderSearchQuery(
+        OrderStatus status,
+        UUID supplierCompanyId,
+        UUID receiverCompanyId,
+        UUID hubId,
+        LocalDate startDate,
+        LocalDate endDate,
+        Long minAmount,
+        Long maxAmount,
+        OrderSearchType searchType
+) {
+    public static OrderSearchQuery of(
+            String statusName,
+            UUID supplierCompanyId,
+            UUID receiverCompanyId,
+            UUID hubId,
+            LocalDate startDate,
+            LocalDate endDate,
+            Long minAmount,
+            Long maxAmount,
+            String searchType
+    ) {
+        return new OrderSearchQuery(
+                OrderStatus.from(statusName),
+                supplierCompanyId,
+                receiverCompanyId,
+                hubId,
+                startDate,
+                endDate,
+                minAmount,
+                maxAmount,
+                OrderSearchType.from(searchType)
+        );
+    }
+
+    public static OrderSearchSpec toSpec(OrderSearchQuery query, RoleCheck roleCheck) {
+        return new OrderSearchSpec(
+                query.status(),
+                query.supplierCompanyId(),
+                query.receiverCompanyId(),
+                query.hubId(),
+                query.startDate(),
+                query.endDate(),
+                query.minAmount(),
+                query.maxAmount(),
+                query.searchType(),
+                roleCheck
+        );
+    }
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/application/dto/result/OrderDetailResult.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/application/dto/result/OrderDetailResult.java
@@ -1,0 +1,78 @@
+package com.firstlogistics.orderservice.application.dto.result;
+
+import com.firstlogistics.orderservice.domain.entity.Order;
+import com.firstlogistics.orderservice.domain.entity.OrderItem;
+import com.firstlogistics.orderservice.domain.enums.OrderCancelType;
+import com.firstlogistics.orderservice.domain.enums.OrderStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record OrderDetailResult(
+        UUID orderId,
+        OrderStatus status,
+        Long totalAmount,
+        LocalDateTime orderedAt,
+        LocalDateTime dueDate,
+
+        UUID supplierCompanyId,
+        UUID supplierManagerId,
+        UUID receiverCompanyId,
+        UUID receiverManagerId,
+
+        UUID deliveryId,
+        String roadAddress,
+        String detailAddress,
+        String requestMemo,
+
+        OrderCancelType cancelType,
+
+        List<OrderItemResult> orderItems
+) {
+    public static OrderDetailResult from(Order order) {
+        return new OrderDetailResult(
+                order.getId().id(),
+                order.getStatus(),
+                order.getTotalAmount().amount(),
+                order.getOrderedAt(),
+                order.getDueDate(),
+
+                order.getSupplier().companyId(),
+                order.getSupplier().managerId(),
+
+                order.getReceiver().companyId(),
+                order.getReceiver().managerId(),
+
+                order.getDeliveryId(),
+
+                order.getDeliveryAddress().roadAddress(),
+                order.getDeliveryAddress().detailAddress(),
+
+                order.getRequestMemo(),
+                order.getCancelType(),
+
+                order.getOrderItems().stream()
+                        .map(OrderItemResult::from)
+                        .toList()
+        );
+    }
+
+    public record OrderItemResult(
+            UUID productId,
+            String productName,
+            Long unitPrice,
+            Integer quantity,
+            Long subTotal
+    ) {
+        public static OrderItemResult from(OrderItem item) {
+            return new OrderItemResult(
+                    item.getProductId(),
+                    item.getProductName(),
+                    item.getUnitPrice().amount(),
+                    item.getQuantity(),
+                    item.getSubTotal().amount()
+            );
+        }
+    }
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/application/dto/result/OrderSummaryResult.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/application/dto/result/OrderSummaryResult.java
@@ -1,0 +1,35 @@
+package com.firstlogistics.orderservice.application.dto.result;
+
+import com.firstlogistics.orderservice.domain.enums.OrderStatus;
+import com.firstlogistics.orderservice.domain.repository.dto.OrderSummaryDto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record OrderSummaryResult(
+        UUID orderId,
+        OrderStatus status,
+        Long totalAmount,
+        UUID supplierCompanyId,
+        UUID supplierManagerId,
+        UUID receiverCompanyId,
+        UUID receiverManagerId,
+        UUID deliveryId,
+        LocalDateTime dueDate,
+        LocalDateTime orderedAt
+) {
+    public static OrderSummaryResult from(OrderSummaryDto dto) {
+        return new OrderSummaryResult(
+                dto.orderId(),
+                dto.status(),
+                dto.totalAmount(),
+                dto.supplierCompanyId(),
+                dto.supplierManagerId(),
+                dto.receiverCompanyId(),
+                dto.receiverManagerId(),
+                dto.deliveryId(),
+                dto.dueDate(),
+                dto.orderedAt()
+        );
+    }
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/enums/OrderStatus.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/enums/OrderStatus.java
@@ -18,13 +18,13 @@ public enum OrderStatus {
 
     public static OrderStatus from(String status) {
         if (status == null || status.isBlank()) {
-            throw new OrderException(OrderErrorCode.INVALID_ORDER_STATUS_CHANGE);
+            return null;
         }
 
         try {
             return OrderStatus.valueOf(status.toUpperCase());
         } catch (IllegalArgumentException e) {
-            throw new OrderException(OrderErrorCode.INVALID_ORDER_STATUS_CHANGE);
+            return null;
         }
     }
 

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/enums/OrderStatus.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/enums/OrderStatus.java
@@ -16,6 +16,18 @@ public enum OrderStatus {
     CANCEL_REQUESTED,   // 주문 취소 요청
     CANCELLED;          // 주문 취소
 
+    public static OrderStatus from(String status) {
+        if (status == null || status.isBlank()) {
+            throw new OrderException(OrderErrorCode.INVALID_ORDER_STATUS_CHANGE);
+        }
+
+        try {
+            return OrderStatus.valueOf(status.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new OrderException(OrderErrorCode.INVALID_ORDER_STATUS_CHANGE);
+        }
+    }
+
     // 상태 전이 Map
     private static final Map<OrderStatus, Set<OrderStatus>> transitions = Map.of(
             PENDING, Set.of(RESERVED, CANCEL_REQUESTED, CANCELLED),
@@ -31,7 +43,7 @@ public enum OrderStatus {
     public void validateNext(OrderStatus next) {
         if (this == next) return;
         if (!transitions.getOrDefault(this, Set.of()).contains(next)) {
-            throw new OrderException(OrderErrorCode.INVALID_ORDER_STATUS);
+            throw new OrderException(OrderErrorCode.INVALID_ORDER_STATUS_CHANGE);
         }
     }
 }

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/exception/OrderErrorCode.java
@@ -30,7 +30,8 @@ public enum OrderErrorCode implements ErrorCode {
     INVALID_MONEY_AMOUNT(HttpStatus.BAD_REQUEST, "ORD013", "금액은 null이거나 0보다 작을 수 없습니다."),
 
     // 주문 상태 전이 & 멱등성 보장
-    INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "ORD014", "허용되지 않은 주문 상태 변경입니다."),
+    INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "ORD027", "유효하지 않은 주문 상태입니다."),
+    INVALID_ORDER_STATUS_CHANGE(HttpStatus.BAD_REQUEST, "ORD014", "허용되지 않은 주문 상태 변경입니다."),
     ALREADY_ACCEPTED(HttpStatus.BAD_REQUEST, "ORD015", "이미 승인된 주문입니다."),
     ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "ORD016", "이미 취소된 주문입니다."),
     ALREADY_CANCEL_REQUESTED(HttpStatus.BAD_REQUEST, "ORD017", "이미 취소 요청된 주문입니다."),

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/exception/OrderErrorCode.java
@@ -30,7 +30,6 @@ public enum OrderErrorCode implements ErrorCode {
     INVALID_MONEY_AMOUNT(HttpStatus.BAD_REQUEST, "ORD013", "금액은 null이거나 0보다 작을 수 없습니다."),
 
     // 주문 상태 전이 & 멱등성 보장
-    INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "ORD027", "유효하지 않은 주문 상태입니다."),
     INVALID_ORDER_STATUS_CHANGE(HttpStatus.BAD_REQUEST, "ORD014", "허용되지 않은 주문 상태 변경입니다."),
     ALREADY_ACCEPTED(HttpStatus.BAD_REQUEST, "ORD015", "이미 승인된 주문입니다."),
     ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "ORD016", "이미 취소된 주문입니다."),

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/repository/OrderQueryRepository.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/repository/OrderQueryRepository.java
@@ -1,0 +1,11 @@
+package com.firstlogistics.orderservice.domain.repository;
+
+import com.firstlogistics.orderservice.domain.repository.dto.OrderSummaryDto;
+import com.firstlogistics.orderservice.domain.specification.OrderSearchSpec;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface OrderQueryRepository {
+
+    Page<OrderSummaryDto> findAll(OrderSearchSpec spec, Pageable pageable);
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/repository/dto/OrderSummaryDto.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/repository/dto/OrderSummaryDto.java
@@ -1,0 +1,19 @@
+package com.firstlogistics.orderservice.domain.repository.dto;
+
+import com.firstlogistics.orderservice.domain.enums.OrderStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record OrderSummaryDto(
+    UUID orderId,
+    OrderStatus status,
+    Long totalAmount,
+    UUID supplierCompanyId,
+    UUID supplierManagerId,
+    UUID receiverCompanyId,
+    UUID receiverManagerId,
+    UUID deliveryId,
+    LocalDateTime dueDate,
+    LocalDateTime orderedAt
+) {}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/service/RoleCheck.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/service/RoleCheck.java
@@ -2,7 +2,15 @@ package com.firstlogistics.orderservice.domain.service;
 
 import com.firstlogistics.orderservice.domain.vo.OrderId;
 
+import java.util.UUID;
+
 public interface RoleCheck {
     boolean canRequestCancel(OrderId orderId);
     boolean canAcceptOrCancel(OrderId orderId);
+    boolean isMaster();
+    boolean isHubManager();
+    boolean isCompanyManager();
+
+    UUID getCurrentUserId();
+    UUID getCurrentUserHubId();
 }

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/service/RoleCheck.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/service/RoleCheck.java
@@ -1,6 +1,5 @@
 package com.firstlogistics.orderservice.domain.service;
 
-import com.firstlogistics.orderservice.domain.entity.Order;
 import com.firstlogistics.orderservice.domain.vo.OrderId;
 
 import java.util.UUID;
@@ -8,7 +7,7 @@ import java.util.UUID;
 public interface RoleCheck {
     boolean canRequestCancel(OrderId orderId);
     boolean canAcceptOrCancel(OrderId orderId);
-    boolean canView(Order order);
+    boolean canView(OrderId orderId, UUID hubId, UUID supplierManagerId, UUID receiverManagerId);
     boolean isMaster();
     boolean isHubManager();
     boolean isCompanyManager();

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/service/RoleCheck.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/service/RoleCheck.java
@@ -1,5 +1,6 @@
 package com.firstlogistics.orderservice.domain.service;
 
+import com.firstlogistics.orderservice.domain.entity.Order;
 import com.firstlogistics.orderservice.domain.vo.OrderId;
 
 import java.util.UUID;
@@ -7,6 +8,7 @@ import java.util.UUID;
 public interface RoleCheck {
     boolean canRequestCancel(OrderId orderId);
     boolean canAcceptOrCancel(OrderId orderId);
+    boolean canView(Order order);
     boolean isMaster();
     boolean isHubManager();
     boolean isCompanyManager();

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/specification/OrderSearchSpec.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/specification/OrderSearchSpec.java
@@ -1,0 +1,41 @@
+package com.firstlogistics.orderservice.domain.specification;
+
+import com.firstlogistics.orderservice.domain.enums.OrderStatus;
+import com.firstlogistics.orderservice.domain.service.RoleCheck;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record OrderSearchSpec(
+        OrderStatus status,
+        UUID supplierCompanyId,
+        UUID receiverCompanyId,
+        UUID hubId,
+        LocalDate startDate,
+        LocalDate endDate,
+        Long minAmount,
+        Long maxAmount,
+        OrderSearchType searchType,
+        RoleCheck roleCheck
+) {
+    public boolean isMaster() {
+        return roleCheck.isMaster();
+    }
+
+    public boolean isHubManager() {
+        return roleCheck.isHubManager();
+    }
+
+    public boolean isCompanyManager() {
+        return roleCheck.isCompanyManager();
+    }
+
+    public UUID getMyHubId() {
+        return roleCheck.getCurrentUserHubId();
+    }
+
+    public UUID getMyUserId() {
+        return roleCheck.getCurrentUserId();
+    }
+
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/specification/OrderSearchType.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/specification/OrderSearchType.java
@@ -2,5 +2,14 @@ package com.firstlogistics.orderservice.domain.specification;
 
 public enum OrderSearchType {
     SENT,
-    RECEIVED
+    RECEIVED;
+
+    public static OrderSearchType from(String value) {
+        if (value == null) return null;
+        try {
+            return OrderSearchType.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
 }

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/specification/OrderSearchType.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/specification/OrderSearchType.java
@@ -1,0 +1,6 @@
+package com.firstlogistics.orderservice.domain.specification;
+
+public enum OrderSearchType {
+    SENT,
+    RECEIVED
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/persistence/config/QueryDslConfig.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/persistence/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.firstlogistics.orderservice.infrastructure.persistence.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}
+

--- a/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/persistence/jpa/OrderQueryRepositoryImpl.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/persistence/jpa/OrderQueryRepositoryImpl.java
@@ -84,12 +84,13 @@ public class OrderQueryRepositoryImpl implements OrderQueryRepository {
         if (spec.isCompanyManager()) {
             UUID userId = spec.getMyUserId();
 
-            if (spec.searchType() == OrderSearchType.RECEIVED) {
-                // 수령 주문 조회
-                return orderJpaEntity.receiverManagerId.eq(userId);
-            } else if (spec.searchType() == OrderSearchType.SENT) {
+            if (spec.searchType() == OrderSearchType.SENT) {
                 // 공급 주문 조회
                 return orderJpaEntity.supplierManagerId.eq(userId);
+            } else {
+                // 수령 주문 조회 (기본값)
+                // null이거나 RECEIVED인 경우
+                return orderJpaEntity.receiverManagerId.eq(userId);
             }
         }
 

--- a/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/persistence/jpa/OrderQueryRepositoryImpl.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/persistence/jpa/OrderQueryRepositoryImpl.java
@@ -1,0 +1,116 @@
+package com.firstlogistics.orderservice.infrastructure.persistence.jpa;
+
+import com.firstlogistics.orderservice.domain.enums.OrderStatus;
+import com.firstlogistics.orderservice.domain.repository.OrderQueryRepository;
+import com.firstlogistics.orderservice.domain.repository.dto.OrderSummaryDto;
+import com.firstlogistics.orderservice.domain.specification.OrderSearchSpec;
+import com.firstlogistics.orderservice.domain.specification.OrderSearchType;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+import static com.firstlogistics.orderservice.infrastructure.persistence.jpa.QOrderJpaEntity.orderJpaEntity;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderQueryRepositoryImpl implements OrderQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<OrderSummaryDto> findAll(OrderSearchSpec spec, Pageable pageable) {
+
+        List<OrderSummaryDto> content = queryFactory
+                .select(Projections.constructor(OrderSummaryDto.class,
+                        orderJpaEntity.id,
+                        orderJpaEntity.status,
+                        orderJpaEntity.totalAmount,
+                        orderJpaEntity.supplierCompanyId,
+                        orderJpaEntity.supplierManagerId,
+                        orderJpaEntity.receiverCompanyId,
+                        orderJpaEntity.receiverManagerId,
+                        orderJpaEntity.deliveryId,
+                        orderJpaEntity.dueDate,
+                        orderJpaEntity.createdAt
+                ))
+                .from(orderJpaEntity)
+                .where(
+                        roleFilter(spec),
+                        statusEq(spec.status()),
+                        dateBetween(spec.startDate(), spec.endDate()),
+                        amountBetween(spec.minAmount(), spec.maxAmount())
+                )
+                .orderBy(orderJpaEntity.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(orderJpaEntity.count())
+                .from(orderJpaEntity)
+                .where(
+                        roleFilter(spec),
+                        statusEq(spec.status()),
+                        dateBetween(spec.startDate(), spec.endDate()),
+                        amountBetween(spec.minAmount(), spec.maxAmount())
+                );
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression roleFilter(OrderSearchSpec spec) {
+        // 마스터 관리자는 모든 주문 조회
+        if (spec.isMaster()) return null;
+
+        // 허브 관리자는 담당 허브 주문만
+        if (spec.isHubManager()) {
+            return orderJpaEntity.supplierHubId.eq(spec.getMyHubId());
+        }
+
+        // 업체 관리자는 담당 업체 주문만
+        if (spec.isCompanyManager()) {
+            UUID userId = spec.getMyUserId();
+
+            if (spec.searchType() == OrderSearchType.RECEIVED) {
+                // 수령 주문 조회
+                return orderJpaEntity.receiverManagerId.eq(userId);
+            } else if (spec.searchType() == OrderSearchType.SENT) {
+                // 공급 주문 조회
+                return orderJpaEntity.supplierManagerId.eq(userId);
+            }
+        }
+
+        return orderJpaEntity.id.isNull();
+    }
+
+    private BooleanExpression statusEq(OrderStatus status) {
+        return status != null ? orderJpaEntity.status.eq(status) : null;
+    }
+
+    private BooleanExpression dateBetween(LocalDate start, LocalDate end) {
+        if (start == null && end == null) return null;
+        if (start != null && end == null) return orderJpaEntity.createdAt.goe(start.atStartOfDay());
+        if (start == null && end != null) return orderJpaEntity.createdAt.loe(end.atTime(LocalTime.MAX));
+
+        return orderJpaEntity.createdAt.between(start.atStartOfDay(), end.atTime(LocalTime.MAX));
+    }
+
+    private BooleanExpression amountBetween(Long min, Long max) {
+        if (min == null && max == null) return null;
+        if (min != null && max == null) return orderJpaEntity.totalAmount.goe(min);
+        if (min == null && max != null) return orderJpaEntity.totalAmount.loe(max);
+
+        return orderJpaEntity.totalAmount.between(min, max);
+    }
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/persistence/jpa/OrderQueryRepositoryImpl.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/persistence/jpa/OrderQueryRepositoryImpl.java
@@ -46,6 +46,7 @@ public class OrderQueryRepositoryImpl implements OrderQueryRepository {
                 ))
                 .from(orderJpaEntity)
                 .where(
+                        orderJpaEntity.deletedAt.isNull(),
                         roleFilter(spec),
                         statusEq(spec.status()),
                         dateBetween(spec.startDate(), spec.endDate()),
@@ -60,6 +61,7 @@ public class OrderQueryRepositoryImpl implements OrderQueryRepository {
                 .select(orderJpaEntity.count())
                 .from(orderJpaEntity)
                 .where(
+                        orderJpaEntity.deletedAt.isNull(),
                         roleFilter(spec),
                         statusEq(spec.status()),
                         dateBetween(spec.startDate(), spec.endDate()),

--- a/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/security/SecurityRoleCheck.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/security/SecurityRoleCheck.java
@@ -36,18 +36,18 @@ public class SecurityRoleCheck implements RoleCheck {
     }
 
     @Override
-    public boolean canView(Order order) {
+    public boolean canView(OrderId orderId, UUID hubId, UUID supplierManagerId, UUID receiverManagerId) {
         if (isMaster()) return true;
 
         if (isHubManager()) {
-            UUID hubId = getCurrentUserHubId();
-            return order.getSupplier().hubId().equals(hubId);
+            UUID myHubId = getCurrentUserHubId();
+            return hubId.equals(myHubId);
         }
 
         if (isCompanyManager()) {
             UUID userId = getCurrentUserId();
-            return order.getSupplier().managerId().equals(userId) ||
-                    order.getReceiver().managerId().equals(userId);
+            return supplierManagerId.equals(userId) ||
+                    receiverManagerId.equals(userId);
         }
 
         return false;

--- a/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/security/SecurityRoleCheck.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/security/SecurityRoleCheck.java
@@ -1,6 +1,5 @@
 package com.firstlogistics.orderservice.infrastructure.security;
 
-import com.firstlogistics.orderservice.domain.entity.Order;
 import com.firstlogistics.orderservice.domain.repository.OrderRepository;
 import com.firstlogistics.orderservice.domain.service.RoleCheck;
 import com.firstlogistics.orderservice.domain.vo.OrderId;
@@ -92,8 +91,11 @@ public class SecurityRoleCheck implements RoleCheck {
     public UUID getCurrentUserHubId() {
         if (!isHubManager()) return null;
 
+        UUID userId = getCurrentUserId();
+        if (userId == null) return null;
+
         try {
-            ApiResponse<HubManagerResponse> response = hubClient.getHubManagerInfo(getCurrentUserId());
+            ApiResponse<HubManagerResponse> response = hubClient.getHubManagerInfo(userId);
             if (response != null && response.getData() != null) {
                 return response.getData().hubId();
             }

--- a/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/security/SecurityRoleCheck.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/security/SecurityRoleCheck.java
@@ -1,5 +1,6 @@
 package com.firstlogistics.orderservice.infrastructure.security;
 
+import com.firstlogistics.orderservice.domain.entity.Order;
 import com.firstlogistics.orderservice.domain.repository.OrderRepository;
 import com.firstlogistics.orderservice.domain.service.RoleCheck;
 import com.firstlogistics.orderservice.domain.vo.OrderId;
@@ -32,6 +33,24 @@ public class SecurityRoleCheck implements RoleCheck {
         return isMaster() ||
                 isHubManagerOf(orderId) ||
                 isSupplierOf(orderId);
+    }
+
+    @Override
+    public boolean canView(Order order) {
+        if (isMaster()) return true;
+
+        if (isHubManager()) {
+            UUID hubId = getCurrentUserHubId();
+            return order.getSupplier().hubId().equals(hubId);
+        }
+
+        if (isCompanyManager()) {
+            UUID userId = getCurrentUserId();
+            return order.getSupplier().managerId().equals(userId) ||
+                    order.getReceiver().managerId().equals(userId);
+        }
+
+        return false;
     }
 
     private boolean hasRole(UserRole role) {

--- a/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/security/SecurityRoleCheck.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/security/SecurityRoleCheck.java
@@ -8,7 +8,6 @@ import com.firstlogistics.orderservice.application.port.dto.HubManagerResponse;
 import common.response.ApiResponse;
 import common.security.entity.enums.UserRole;
 import common.security.security.util.SecurityUtils;
-import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -36,34 +35,59 @@ public class SecurityRoleCheck implements RoleCheck {
     }
 
     private boolean hasRole(UserRole role) {
-        UserRole currentRole = getCurrentUserRole();
-        return currentRole != null && currentRole == role;
+        try {
+            UserRole currentRole = SecurityUtils.currentUser().getRole();
+            return currentRole != null && currentRole == role;
+        } catch (Exception e) {
+            log.warn("권한 확인 중 인증 예외 발생: {}", e.getMessage());
+            return false;
+        }
     }
 
-    private boolean isMaster() {
+    @Override
+    public boolean isMaster() {
         return hasRole(UserRole.MASTER);
+    }
+
+    @Override
+    public boolean isHubManager() {
+        return hasRole(UserRole.HUB_MANAGER);
+    }
+
+    @Override
+    public boolean isCompanyManager() {
+        return hasRole(UserRole.COMPANY_MANAGER);
+    }
+
+    @Override
+    public UUID getCurrentUserId() {
+        try {
+            return SecurityUtils.currentUser().getUserId();
+        } catch (Exception e) {
+            log.warn("권한 확인 중 인증 예외 발생: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    @Override
+    public UUID getCurrentUserHubId() {
+        if (!isHubManager()) return null;
+
+        try {
+            ApiResponse<HubManagerResponse> response = hubClient.getHubManagerInfo(getCurrentUserId());
+            if (response != null && response.getData() != null) {
+                return response.getData().hubId();
+            }
+        } catch (Exception e) {
+            log.error("허브 정보 조회 실패: {}", e.getMessage());
+        }
+        return null;
     }
 
     private boolean isHubManagerOf(OrderId orderId) {
         if (hasRole(UserRole.HUB_MANAGER)) {
-            UUID userId = getCurrentUserId();
-
-            try {
-                // 허브 서비스에서 본인의 소속 허브 ID를 가져와서 비교
-                ApiResponse<HubManagerResponse> response = hubClient.getHubManagerInfo(userId);
-
-                if (response != null && response.getStatus().is2xxSuccessful() && response.getData() != null) {
-                    UUID hubId = response.getData().hubId();
-                    return orderRepository.existsByIdAndSupplierHubId(orderId, hubId);
-                }
-                return false;
-            } catch (FeignException.NotFound e) {
-                log.info("허브 관리자 정보를 찾을 수 없습니다. userId: {}", userId);
-                return false;
-            } catch (Exception e) {
-                log.error("허브 권한 검증 중 외부 서비스 오류 발생: {}", e.getMessage());
-                return false;
-            }
+            UUID hubId = getCurrentUserHubId();
+            return orderRepository.existsByIdAndSupplierHubId(orderId, hubId);
         }
         return false;
     }
@@ -82,21 +106,4 @@ public class SecurityRoleCheck implements RoleCheck {
         return false;
     }
 
-    private UUID getCurrentUserId() {
-        try {
-            return SecurityUtils.currentUser().getUserId();
-        } catch (Exception e) {
-            log.warn("권한 확인 중 인증 예외 발생: {}", e.getMessage());
-            return null;
-        }
-    }
-
-    private UserRole getCurrentUserRole() {
-        try {
-            return SecurityUtils.currentUser().getRole();
-        } catch (Exception e) {
-            log.warn("권한 확인 중 인증 예외 발생: {}", e.getMessage());
-            return null;
-        }
-    }
 }

--- a/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/security/SecurityRoleCheck.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/security/SecurityRoleCheck.java
@@ -1,5 +1,7 @@
 package com.firstlogistics.orderservice.infrastructure.security;
 
+import com.firstlogistics.orderservice.domain.exception.OrderErrorCode;
+import com.firstlogistics.orderservice.domain.exception.OrderException;
 import com.firstlogistics.orderservice.domain.repository.OrderRepository;
 import com.firstlogistics.orderservice.domain.service.RoleCheck;
 import com.firstlogistics.orderservice.domain.vo.OrderId;
@@ -8,6 +10,7 @@ import com.firstlogistics.orderservice.application.port.dto.HubManagerResponse;
 import common.response.ApiResponse;
 import common.security.entity.enums.UserRole;
 import common.security.security.util.SecurityUtils;
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -53,13 +56,8 @@ public class SecurityRoleCheck implements RoleCheck {
     }
 
     private boolean hasRole(UserRole role) {
-        try {
-            UserRole currentRole = SecurityUtils.currentUser().getRole();
-            return currentRole != null && currentRole == role;
-        } catch (Exception e) {
-            log.warn("권한 확인 중 인증 예외 발생: {}", e.getMessage());
-            return false;
-        }
+        UserRole currentRole = SecurityUtils.currentUser().getRole();
+        return currentRole != null && currentRole == role;
     }
 
     @Override
@@ -99,8 +97,11 @@ public class SecurityRoleCheck implements RoleCheck {
             if (response != null && response.getData() != null) {
                 return response.getData().hubId();
             }
+        } catch (FeignException.NotFound e) {
+            return null;
         } catch (Exception e) {
-            log.error("허브 정보 조회 실패: {}", e.getMessage());
+            log.error("허브 서비스 호출 중 시스템 에러 발생: {}", e.getMessage());
+            throw new OrderException(OrderErrorCode.EXTERNAL_SERVICE_ERROR);
         }
         return null;
     }

--- a/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/web/config/WebMvcConfig.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/web/config/WebMvcConfig.java
@@ -1,0 +1,21 @@
+package com.firstlogistics.orderservice.infrastructure.web.config;
+
+import com.firstlogistics.orderservice.infrastructure.web.resolver.CustomPageableResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final CustomPageableResolver customPageableResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(0, customPageableResolver);
+    }
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/web/resolver/CustomPageableResolver.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/web/resolver/CustomPageableResolver.java
@@ -1,0 +1,41 @@
+package com.firstlogistics.orderservice.infrastructure.web.resolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.Set;
+
+@Component
+public class CustomPageableResolver extends PageableHandlerMethodArgumentResolver {
+
+    private static final Set<Integer> ALLOWED_SIZES = Set.of(10, 30, 50);
+    private static final int DEFAULT_SIZE = 10;
+
+    @Override
+    public Pageable resolveArgument(
+            MethodParameter methodParameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory) {
+
+        Pageable pageable = super.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+
+        int pageSize = pageable.getPageSize();
+
+        if (!ALLOWED_SIZES.contains(pageSize)) {
+            pageSize = DEFAULT_SIZE;
+        }
+
+        return PageRequest.of(
+                pageable.getPageNumber(),
+                pageSize,
+                pageable.getSort()
+        );
+    }
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/presentation/OrderController.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/presentation/OrderController.java
@@ -1,14 +1,22 @@
 package com.firstlogistics.orderservice.presentation;
 
 import com.firstlogistics.orderservice.application.OrderCommandService;
+import com.firstlogistics.orderservice.application.OrderQueryService;
 import com.firstlogistics.orderservice.presentation.dto.request.CreateOrderRequest;
+import com.firstlogistics.orderservice.presentation.dto.request.SearchOrderRequest;
 import com.firstlogistics.orderservice.presentation.dto.response.OrderIdResponse;
 import com.firstlogistics.orderservice.presentation.dto.response.OrderStatusResponse;
+import com.firstlogistics.orderservice.presentation.dto.response.OrderSummaryResponse;
 import common.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,6 +33,7 @@ import java.util.UUID;
 public class OrderController {
 
     private final OrderCommandService orderCommandService;
+    private final OrderQueryService orderQueryService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<OrderIdResponse>> createOrder(
@@ -33,6 +42,17 @@ public class OrderController {
         UUID id = orderCommandService.createOrder(request.toCommand());
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(OrderSuccessCode.ORDER_CREATED, OrderIdResponse.from(id)));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<OrderSummaryResponse>>> getOrders(
+            @ModelAttribute SearchOrderRequest request,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        Page<OrderSummaryResponse> response = orderQueryService.getOrders(request.toQuery(), pageable)
+                .map(OrderSummaryResponse::from);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(OrderSuccessCode.ORDER_OK, response));
     }
 
     @PatchMapping("/{orderId}/acceptance")

--- a/order-service/src/main/java/com/firstlogistics/orderservice/presentation/OrderController.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/presentation/OrderController.java
@@ -4,6 +4,7 @@ import com.firstlogistics.orderservice.application.OrderCommandService;
 import com.firstlogistics.orderservice.application.OrderQueryService;
 import com.firstlogistics.orderservice.presentation.dto.request.CreateOrderRequest;
 import com.firstlogistics.orderservice.presentation.dto.request.SearchOrderRequest;
+import com.firstlogistics.orderservice.presentation.dto.response.OrderDetailResponse;
 import com.firstlogistics.orderservice.presentation.dto.response.OrderIdResponse;
 import com.firstlogistics.orderservice.presentation.dto.response.OrderStatusResponse;
 import com.firstlogistics.orderservice.presentation.dto.response.OrderSummaryResponse;
@@ -53,6 +54,15 @@ public class OrderController {
                 .map(OrderSummaryResponse::from);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.success(OrderSuccessCode.ORDER_OK, response));
+    }
+
+    @GetMapping("/{orderId}")
+    public ResponseEntity<ApiResponse<OrderDetailResponse>> getOrder(
+            @PathVariable UUID orderId
+    ) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(OrderSuccessCode.ORDER_OK,
+                        OrderDetailResponse.from(orderQueryService.getOrder(orderId))));
     }
 
     @PatchMapping("/{orderId}/acceptance")

--- a/order-service/src/main/java/com/firstlogistics/orderservice/presentation/OrderController.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/presentation/OrderController.java
@@ -47,7 +47,7 @@ public class OrderController {
 
     @GetMapping
     public ResponseEntity<ApiResponse<Page<OrderSummaryResponse>>> getOrders(
-            @ModelAttribute SearchOrderRequest request,
+            @ModelAttribute @Valid SearchOrderRequest request,
             @PageableDefault(size = 10) Pageable pageable
     ) {
         Page<OrderSummaryResponse> response = orderQueryService.getOrders(request.toQuery(), pageable)

--- a/order-service/src/main/java/com/firstlogistics/orderservice/presentation/dto/request/CreateOrderRequest.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/presentation/dto/request/CreateOrderRequest.java
@@ -1,6 +1,6 @@
 package com.firstlogistics.orderservice.presentation.dto.request;
 
-import com.firstlogistics.orderservice.application.dto.CreateOrderCommand;
+import com.firstlogistics.orderservice.application.dto.command.CreateOrderCommand;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.Min;

--- a/order-service/src/main/java/com/firstlogistics/orderservice/presentation/dto/request/SearchOrderRequest.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/presentation/dto/request/SearchOrderRequest.java
@@ -1,6 +1,7 @@
 package com.firstlogistics.orderservice.presentation.dto.request;
 
 import com.firstlogistics.orderservice.application.dto.query.OrderSearchQuery;
+import jakarta.validation.constraints.AssertTrue;
 
 import java.time.LocalDate;
 import java.util.UUID;
@@ -16,6 +17,18 @@ public record SearchOrderRequest(
         Long maxAmount,
         String searchType
 ) {
+    @AssertTrue(message = "시작일은 종료일보다 이전이어야 합니다.")
+    public boolean isValidDateRange() {
+        if (startDate == null || endDate == null) return true;
+        return !startDate.isAfter(endDate);
+    }
+
+    @AssertTrue(message = "최소 금액은 최대 금액보다 클 수 없습니다.")
+    public boolean isValidAmountRange() {
+        if (minAmount == null || maxAmount == null) return true;
+        return minAmount <= maxAmount;
+    }
+
     public OrderSearchQuery toQuery() {
         return OrderSearchQuery.of(
                 this.status,

--- a/order-service/src/main/java/com/firstlogistics/orderservice/presentation/dto/request/SearchOrderRequest.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/presentation/dto/request/SearchOrderRequest.java
@@ -1,0 +1,32 @@
+package com.firstlogistics.orderservice.presentation.dto.request;
+
+import com.firstlogistics.orderservice.application.dto.query.OrderSearchQuery;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record SearchOrderRequest(
+        String status,
+        UUID supplierCompanyId,
+        UUID receiverCompanyId,
+        UUID hubId,
+        LocalDate startDate,
+        LocalDate endDate,
+        Long minAmount,
+        Long maxAmount,
+        String searchType
+) {
+    public OrderSearchQuery toQuery() {
+        return OrderSearchQuery.of(
+                this.status,
+                this.supplierCompanyId,
+                this.receiverCompanyId,
+                this.hubId,
+                this.startDate,
+                this.endDate,
+                this.minAmount,
+                this.maxAmount,
+                this.searchType
+        );
+    }
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/presentation/dto/response/OrderDetailResponse.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/presentation/dto/response/OrderDetailResponse.java
@@ -1,0 +1,70 @@
+package com.firstlogistics.orderservice.presentation.dto.response;
+
+import com.firstlogistics.orderservice.application.dto.result.OrderDetailResult;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record OrderDetailResponse(
+        UUID orderId,
+        String status,
+        Long totalAmount,
+        LocalDateTime orderedAt,
+        LocalDateTime dueDate,
+
+        SupplierInfo supplier,
+        ReceiverInfo receiver,
+
+        UUID deliveryId,
+        String requestMemo,
+
+        String cancelType,
+
+        List<OrderItemResponse> items
+) {
+    public record SupplierInfo(
+            UUID companyId,
+            UUID managerId
+    ) {}
+
+    public record ReceiverInfo(
+            UUID companyId,
+            UUID managerId,
+            String roadAddress,
+            String detailAddress
+    ) {}
+
+    public record OrderItemResponse(
+            UUID productId,
+            String productName,
+            Long unitPrice,
+            Integer quantity,
+            Long subTotal
+    ) {}
+
+    public static OrderDetailResponse from(OrderDetailResult result) {
+        return new OrderDetailResponse(
+                result.orderId(),
+                result.status().name(),
+                result.totalAmount(),
+                result.orderedAt(),
+                result.dueDate(),
+                new SupplierInfo(result.supplierCompanyId(), result.supplierManagerId()),
+                new ReceiverInfo(result.receiverCompanyId(), result.receiverManagerId(), result.roadAddress(), result.detailAddress()),
+                result.deliveryId(),
+                result.requestMemo(),
+                result.cancelType() != null ? result.cancelType().name() : null,
+                result.orderItems().stream()
+                        .map(i -> new OrderItemResponse(
+                                i.productId(),
+                                i.productName(),
+                                i.unitPrice(),
+                                i.quantity(),
+                                i.subTotal()
+                                )
+                        )
+                        .toList()
+        );
+    }
+}

--- a/order-service/src/main/java/com/firstlogistics/orderservice/presentation/dto/response/OrderSummaryResponse.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/presentation/dto/response/OrderSummaryResponse.java
@@ -1,0 +1,34 @@
+package com.firstlogistics.orderservice.presentation.dto.response;
+
+import com.firstlogistics.orderservice.application.dto.result.OrderSummaryResult;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record OrderSummaryResponse (
+    UUID orderId,
+    String status,
+    Long totalAmount,
+    UUID supplierCompanyId,
+    UUID supplierManagerId,
+    UUID receiverCompanyId,
+    UUID receiverManagerId,
+    UUID deliveryId,
+    LocalDateTime dueDate,
+    LocalDateTime orderedAt
+) {
+    public static OrderSummaryResponse from(OrderSummaryResult result) {
+        return new OrderSummaryResponse(
+                result.orderId(),
+                result.status().name(),
+                result.totalAmount(),
+                result.supplierCompanyId(),
+                result.supplierManagerId(),
+                result.receiverCompanyId(),
+                result.receiverManagerId(),
+                result.deliveryId(),
+                result.dueDate(),
+                result.orderedAt()
+        );
+    }
+}

--- a/order-service/src/test/java/com/firstlogistics/orderservice/application/OrderCommandServiceIntegrationTest.java
+++ b/order-service/src/test/java/com/firstlogistics/orderservice/application/OrderCommandServiceIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.firstlogistics.orderservice.application;
 
-import com.firstlogistics.orderservice.application.dto.CreateOrderCommand;
+import com.firstlogistics.orderservice.application.dto.command.CreateOrderCommand;
 import com.firstlogistics.orderservice.application.port.CompanyPort;
 import com.firstlogistics.orderservice.application.port.dto.CompanyResponse;
 import com.firstlogistics.orderservice.domain.event.OrderCreatedEvent;

--- a/order-service/src/test/java/com/firstlogistics/orderservice/application/OrderCommandServiceTest.java
+++ b/order-service/src/test/java/com/firstlogistics/orderservice/application/OrderCommandServiceTest.java
@@ -1,6 +1,6 @@
 package com.firstlogistics.orderservice.application;
 
-import com.firstlogistics.orderservice.application.dto.CreateOrderCommand;
+import com.firstlogistics.orderservice.application.dto.command.CreateOrderCommand;
 import com.firstlogistics.orderservice.application.port.CompanyPort;
 import com.firstlogistics.orderservice.application.port.dto.CompanyResponse;
 import com.firstlogistics.orderservice.domain.entity.Order;

--- a/order-service/src/test/java/com/firstlogistics/orderservice/application/OrderCommandServiceTest.java
+++ b/order-service/src/test/java/com/firstlogistics/orderservice/application/OrderCommandServiceTest.java
@@ -152,7 +152,7 @@ class OrderCommandServiceTest {
         // when & then
         assertThatThrownBy(() -> orderCommandService.acceptOrder(orderId))
                 .isInstanceOf(OrderException.class)
-                .hasMessage(OrderErrorCode.INVALID_ORDER_STATUS.getMessage());
+                .hasMessage(OrderErrorCode.INVALID_ORDER_STATUS_CHANGE.getMessage());
         verify(orderRepository, never()).save(any(Order.class));
         verify(eventPublisher, never()).publishEvent(any());
     }


### PR DESCRIPTION
### 📌 관련 이슈
- close #153

### 💡 작업 내용
- 주문 목록 조회 API 구현 (`GET /api/v1/orders`)
- 주문 단건 조회 API (`GET /api/v1/orders/{orderId}`)

### 🔍 변경 이유
- 

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 주문 검색/필터링 추가(상태, 공급업체·수취인·허브, 날짜·금액 범위, 송수신 구분)
  * 주문 목록 조회 및 개별 주문 상세 조회 API 추가

* **개선 사항**
  * 페이지네이션 기본 및 허용 페이지 크기(10/30/50) 적용(기본 10)
  * 역할 기반 접근 제어 강화로 권한 있는 사용자만 주문 열람 가능
  * 일부 오류 코드/메시지명 정비 (잘못된 상태 전환 관련)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->