### PR TITLE
feat: 주문 상태별 취소 로직 분리 & 재고 보상 트랜잭션 구현

### DIFF
--- a/order-service/src/main/java/com/firstlogistics/orderservice/application/OrderCommandService.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/application/OrderCommandService.java
@@ -143,7 +143,7 @@ public class OrderCommandService {
 
         order.rejectBySystem();
 
-        Events.trigger(OrderCancelledEvent.from(order));
+        Events.trigger(OrderCancelledEvent.of(order, true));
 
         orderRepository.save(order);
     }
@@ -182,7 +182,7 @@ public class OrderCommandService {
 
         orderRepository.save(order);
 
-        Events.trigger(OrderCancelledEvent.from(order));
+        Events.trigger(OrderCancelledEvent.of(order, false));
 
         return order.getStatus().name();
     }

--- a/order-service/src/main/java/com/firstlogistics/orderservice/domain/event/OrderCancelledEvent.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/domain/event/OrderCancelledEvent.java
@@ -9,7 +9,8 @@ import java.util.UUID;
 public record OrderCancelledEvent(
         UUID orderId,
         UUID supplierCompanyId,
-        List<OrderCancelledEvent.OrderItemInfo> orderItems
+        List<OrderCancelledEvent.OrderItemInfo> orderItems,
+        boolean isConfirmed
 ) {
     public record OrderItemInfo(
             UUID productId,
@@ -23,13 +24,14 @@ public record OrderCancelledEvent(
         }
     }
 
-    public static OrderCancelledEvent from(Order order) {
+    public static OrderCancelledEvent of(Order order, boolean isConfirmed) {
         return new OrderCancelledEvent(
                 order.getId().id(),
                 order.getSupplier().companyId(),
                 order.getOrderItems().stream()
                         .map(OrderCancelledEvent.OrderItemInfo::from)
-                        .toList()
+                        .toList(),
+                isConfirmed
         );
     }
 }

--- a/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/messaging/config/InventoryConsumerConfig.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/messaging/config/InventoryConsumerConfig.java
@@ -2,7 +2,7 @@ package com.firstlogistics.orderservice.infrastructure.messaging.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.firstlogistics.orderservice.infrastructure.messaging.event.InventoryReservationFailedEvent;
-import com.firstlogistics.orderservice.infrastructure.messaging.event.InventoryReservedEvent;
+import com.firstlogistics.orderservice.infrastructure.messaging.event.InventoryResultEvent;
 import common.kafka.config.KafkaConsumerConfig;
 import lombok.RequiredArgsConstructor;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -21,24 +21,24 @@ public class InventoryConsumerConfig {
     private final KafkaConsumerConfig kafkaConsumerConfig;
     private final ObjectMapper objectMapper;
 
-    // ----- 재고 예약 성공 ----- //
+    // ----- 재고 이벤트 성공 ----- //
     @Bean
-    public ConsumerFactory<String, InventoryReservedEvent> inventoryReservedConsumerFactory() {
-        return createFactory(InventoryReservedEvent.class);
+    public ConsumerFactory<String, InventoryResultEvent> inventoryResultConsumerFactory() {
+        return createFactory(InventoryResultEvent.class);
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, InventoryReservedEvent> inventoryReservedListenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<String, InventoryReservedEvent> factory =
+    public ConcurrentKafkaListenerContainerFactory<String, InventoryResultEvent> inventoryResultListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, InventoryResultEvent> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
 
-        factory.setConsumerFactory(inventoryReservedConsumerFactory());
+        factory.setConsumerFactory(inventoryResultConsumerFactory());
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
 
         return factory;
     }
 
-    // ----- 재고 예약 성공 ----- //
+    // ----- 재고 예약 실패 ----- //
     @Bean
     public ConsumerFactory<String, InventoryReservationFailedEvent> inventoryReservationFailedConsumerFactory() {
         return createFactory(InventoryReservationFailedEvent.class);

--- a/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/messaging/consumer/InventoryEventConsumer.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/messaging/consumer/InventoryEventConsumer.java
@@ -2,7 +2,7 @@ package com.firstlogistics.orderservice.infrastructure.messaging.consumer;
 
 import com.firstlogistics.orderservice.application.OrderCommandService;
 import com.firstlogistics.orderservice.infrastructure.messaging.event.InventoryReservationFailedEvent;
-import com.firstlogistics.orderservice.infrastructure.messaging.event.InventoryReservedEvent;
+import com.firstlogistics.orderservice.infrastructure.messaging.event.InventoryResultEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -16,15 +16,18 @@ public class InventoryEventConsumer {
 
     private static final String INVENTORY_RESERVED = "inventory.reserved";
     private static final String INVENTORY_RESERVATION_FAILED = "inventory.reservation.failed";
+    private static final String INVENTORY_CONFIRMED = "inventory.confirmed";
+    private static final String INVENTORY_RESERVATION_CANCELLED = "inventory.reservation.cancelled";
+    private static final String INVENTORY_CANCELLED = "inventory.cancelled";
 
     private final OrderCommandService orderCommandService;
 
     @KafkaListener(
             topics = INVENTORY_RESERVED,
             groupId = "order-service",
-            containerFactory = "inventoryReservedListenerContainerFactory"
+            containerFactory = "inventoryResultListenerContainerFactory"
     )
-    public void onInventoryReserved(InventoryReservedEvent event, Acknowledgment ack) {
+    public void onInventoryReserved(InventoryResultEvent event, Acknowledgment ack) {
         log.info("[Kafka] Received: topic={}, orderId={}", INVENTORY_RESERVED, event.orderId());
         orderCommandService.reserve(event.orderId(), true);
         ack.acknowledge();
@@ -41,5 +44,33 @@ public class InventoryEventConsumer {
         ack.acknowledge();
     }
 
+    @KafkaListener(
+            topics = INVENTORY_CONFIRMED,
+            groupId = "order-service",
+            containerFactory = "inventoryResultListenerContainerFactory"
+    )
+    public void onInventoryConfirmed(InventoryResultEvent event, Acknowledgment ack) {
+        log.info("[Kafka] Received: topic={}, orderId={}", INVENTORY_CONFIRMED, event.orderId());
+        ack.acknowledge();
+    }
 
+    @KafkaListener(
+            topics = INVENTORY_RESERVATION_CANCELLED,
+            groupId = "order-service",
+            containerFactory = "inventoryResultListenerContainerFactory"
+    )
+    public void onInventoryReservationCancelled(InventoryResultEvent event, Acknowledgment ack) {
+        log.info("[Kafka] Received: topic={}, orderId={}", INVENTORY_RESERVATION_CANCELLED, event.orderId());
+        ack.acknowledge();
+    }
+
+    @KafkaListener(
+            topics = INVENTORY_CANCELLED,
+            groupId = "order-service",
+            containerFactory = "inventoryResultListenerContainerFactory"
+    )
+    public void onInventoryCancelled(InventoryResultEvent event, Acknowledgment ack) {
+        log.info("[Kafka] Received: topic={}, orderId={}", INVENTORY_CANCELLED, event.orderId());
+        ack.acknowledge();
+    }
 }

--- a/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/messaging/event/InventoryResultEvent.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/messaging/event/InventoryResultEvent.java
@@ -2,7 +2,7 @@ package com.firstlogistics.orderservice.infrastructure.messaging.event;
 
 import java.util.UUID;
 
-public record InventoryReservedEvent(
+public record InventoryResultEvent(
         UUID orderId
 ) {
 }

--- a/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/messaging/producer/OrderEventKafkaProducer.java
+++ b/order-service/src/main/java/com/firstlogistics/orderservice/infrastructure/messaging/producer/OrderEventKafkaProducer.java
@@ -72,7 +72,8 @@ public class OrderEventKafkaProducer {
                 originalEvent.order().supplierCompanyId(),
                 originalEvent.order().items().stream()
                         .map(item -> new OrderCancelledEvent.OrderItemInfo(item.productId(), item.quantity()))
-                        .toList()
+                        .toList(),
+                true
         );
 
         send(ORDER_CANCELLED, orderId.toString(), cancelEvent, orderId);


### PR DESCRIPTION
### 📌 관련 이슈
- close #192 

### 💡 작업 내용
- `OrderCancelledEvent`에 `isConfirmed` 필드 추가
- 재고 확정, 재고 예약 취소, 재고 취소 이벤트 컨슈머 구현

### 🔍 변경 이유
- 

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩터**
  * 주문 취소 이벤트가 시스템 트리거 및 권한 검증 취소를 구분하도록 개선되었습니다.
  * 인벤토리 메시징 처리가 예약, 확인, 취소 등 다양한 인벤토리 상태를 지원하도록 업데이트되었습니다.
  * 인벤토리 이벤트 소비 구조가 다중 토픽 처리를 위해 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->